### PR TITLE
feat: Add HTTP catalog that can be used to call HTTP endpoints and tu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Simple query using multiple catalogs:
                        + "outer apply fs#file(concat('/path/to/files/', d.fileName)) f "
                        + "where d._docType = 'pdfFiles'";
 
-        CompiledQuery compiledQuery = Payloadbuilder.compile(query, session);
+        CompiledQuery compiledQuery = Payloadbuilder.compile(session, query);
         QueryResult queryResult = compiledQuery.execute(session);
         JsonOutputWriter writer = new JsonOutputWriter(new PrintWriter(System.out));
         while (queryResult.hasMoreResults())

--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/Catalog.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/Catalog.java
@@ -66,10 +66,21 @@ public abstract class Catalog
 
     /**
      * Return the table schema information for provided table.
+     *
+     * @deprecated Use {@link #getTableSchema(IExecutionContext, String, QualifiedName, List)} instead
      */
+    @Deprecated
     public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
     {
         return TableSchema.EMPTY;
+    }
+
+    /**
+     * Return the table schema information for provided table.
+     */
+    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
+    {
+        return getTableSchema(session, catalogAlias, table);
     }
 
     /** Create a scan {@link IDatasource} for provided table */

--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/IDatasourceOptions.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/IDatasourceOptions.java
@@ -1,5 +1,7 @@
 package se.kuseman.payloadbuilder.api.catalog;
 
+import java.util.List;
+
 import se.kuseman.payloadbuilder.api.QualifiedName;
 import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
 import se.kuseman.payloadbuilder.api.execution.ValueVector;
@@ -14,4 +16,7 @@ public interface IDatasourceOptions
 
     /** Return value for provided option name. If no option found with provided name null is returned */
     ValueVector getOption(QualifiedName name, IExecutionContext context);
+
+    /** Return options */
+    List<Option> getOptions();
 }

--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/Index.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/Index.java
@@ -55,9 +55,8 @@ public class Index
         {
             return true;
         }
-        else if (obj instanceof Index)
+        else if (obj instanceof Index that)
         {
-            Index that = (Index) obj;
             return table.equals(that.table)
                     && columns.equals(that.columns)
                     && columnsType == that.columnsType;

--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/TableFunctionInfo.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/TableFunctionInfo.java
@@ -38,10 +38,7 @@ public abstract class TableFunctionInfo extends FunctionInfo
      * @param arguments Function arguments
      * @param options Options for this table source such as batch size etc.
      */
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, IDatasourceOptions options)
-    {
-        return TupleIterator.EMPTY;
-    }
+    public abstract TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, IDatasourceOptions options);
 
     /** Exception that can be thrown during schema resolving for TVS to properly trigg compile exception. */
     public static class SchemaResolveException extends RuntimeException

--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/TableSchema.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/TableSchema.java
@@ -56,12 +56,17 @@ public class TableSchema
         {
             return true;
         }
-        else if (obj instanceof TableSchema)
+        else if (obj instanceof TableSchema that)
         {
-            TableSchema that = (TableSchema) obj;
             return schema.equals(that.schema)
                     && indices.equals(that.indices);
         }
         return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return schema.toString() + " (" + indices + ")";
     }
 }

--- a/payloadbuilder-api/src/test/java/se/kuseman/payloadbuilder/test/ExpressionTestUtils.java
+++ b/payloadbuilder-api/src/test/java/se/kuseman/payloadbuilder/test/ExpressionTestUtils.java
@@ -10,6 +10,7 @@ import se.kuseman.payloadbuilder.api.catalog.Column.Type;
 import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
 import se.kuseman.payloadbuilder.api.execution.UTF8String;
 import se.kuseman.payloadbuilder.api.expression.IExpression;
+import se.kuseman.payloadbuilder.api.expression.ILiteralNullExpression;
 import se.kuseman.payloadbuilder.api.expression.ILiteralStringExpression;
 
 /** Test utils when working with {@link IExpression}'s */
@@ -22,6 +23,15 @@ public class ExpressionTestUtils
         ILiteralStringExpression mock = Mockito.mock(ILiteralStringExpression.class);
         when(mock.eval(any(IExecutionContext.class))).thenReturn(VectorTestUtils.vv(Type.String, value));
         when(mock.getValue()).thenReturn(UTF8String.from(value));
+        when(mock.toString()).thenReturn(value);
+        return mock;
+    }
+
+    /** Create a null expression */
+    public static ILiteralNullExpression createNullExpression()
+    {
+        ILiteralNullExpression mock = Mockito.mock(ILiteralNullExpression.class);
+        when(mock.eval(any(IExecutionContext.class))).thenReturn(VectorTestUtils.vv(Type.Any, new Object[] { null }));
         return mock;
     }
 }

--- a/payloadbuilder-catalog/pom.xml
+++ b/payloadbuilder-catalog/pom.xml
@@ -96,6 +96,12 @@
             <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <version>5.15.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- JDBC drivers -->
         <dependency>

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/ESCatalog.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/ESCatalog.java
@@ -29,6 +29,7 @@ import se.kuseman.payloadbuilder.api.catalog.IDatasourceOptions;
 import se.kuseman.payloadbuilder.api.catalog.IPredicate;
 import se.kuseman.payloadbuilder.api.catalog.ISortItem;
 import se.kuseman.payloadbuilder.api.catalog.Index;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableSchema;
@@ -123,7 +124,7 @@ public class ESCatalog extends Catalog
     }
 
     @Override
-    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
     {
         ESType esType = ESType.of(session, catalogAlias, table);
         // All indexed non-free-text fields are index candidates

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/FallbackResponseTransformer.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/FallbackResponseTransformer.java
@@ -1,0 +1,114 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+
+import se.kuseman.payloadbuilder.api.catalog.Column;
+import se.kuseman.payloadbuilder.api.catalog.Column.Type;
+import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
+import se.kuseman.payloadbuilder.api.catalog.Schema;
+import se.kuseman.payloadbuilder.api.execution.ObjectTupleVector;
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
+import se.kuseman.payloadbuilder.api.execution.TupleVector;
+import se.kuseman.payloadbuilder.api.execution.UTF8String;
+import se.kuseman.payloadbuilder.api.execution.ValueVector;
+
+/** Fallback transformer that simply returns the response as a string in a single column */
+class FallbackResponseTransformer implements IResponseTransformer
+{
+    static final Schema HEADERS_SCHEMA = Schema.of(new Column("name", ResolvedType.of(Type.String)), new Column("value", ResolvedType.of(Type.String)));
+    static final Schema SCHEMA = new Schema(List.of(new Column("body", ResolvedType.of(Column.Type.String)), new Column("headers", ResolvedType.table(HEADERS_SCHEMA))));
+
+    @Override
+    public boolean canHandle(HttpUriRequestBase request, ClassicHttpResponse response)
+    {
+        return true;
+    }
+
+    @Override
+    public TupleIterator transform(HttpUriRequestBase request, ClassicHttpResponse response)
+    {
+        try
+        {
+            String body = IOUtils.toString(response.getEntity()
+                    .getContent(), StandardCharsets.UTF_8);
+            return TupleIterator.singleton(new TupleVector()
+            {
+                @Override
+                public Schema getSchema()
+                {
+                    return SCHEMA;
+                }
+
+                @Override
+                public int getRowCount()
+                {
+                    return 1;
+                }
+
+                @Override
+                public ValueVector getColumn(int column)
+                {
+                    return new ValueVector()
+                    {
+                        @Override
+                        public ResolvedType type()
+                        {
+                            return SCHEMA.getColumns()
+                                    .get(column)
+                                    .getType();
+                        }
+
+                        @Override
+                        public int size()
+                        {
+                            return 1;
+                        }
+
+                        @Override
+                        public boolean isNull(int row)
+                        {
+                            if (column == 0)
+                            {
+                                return body == null;
+                            }
+
+                            return false;
+                        }
+
+                        @Override
+                        public UTF8String getString(int row)
+                        {
+                            return UTF8String.from(body);
+                        }
+
+                        @Override
+                        public TupleVector getTable(int row)
+                        {
+                            final Header[] headers = response.getHeaders();
+
+                            return new ObjectTupleVector(HEADERS_SCHEMA, headers.length, (hrow, hcol) ->
+                            {
+                                Header header = headers[hrow];
+                                return hcol == 0 ? header.getName()
+                                        : header.getValue();
+                            });
+                        }
+                    };
+                }
+            });
+
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error extracting response body", e);
+        }
+    }
+
+}

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/HttpCatalog.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/HttpCatalog.java
@@ -1,0 +1,291 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.http.HttpHeaders;
+
+import se.kuseman.payloadbuilder.api.QualifiedName;
+import se.kuseman.payloadbuilder.api.catalog.Catalog;
+import se.kuseman.payloadbuilder.api.catalog.CompileException;
+import se.kuseman.payloadbuilder.api.catalog.DatasourceData;
+import se.kuseman.payloadbuilder.api.catalog.IDatasource;
+import se.kuseman.payloadbuilder.api.catalog.IPredicate;
+import se.kuseman.payloadbuilder.api.catalog.Index;
+import se.kuseman.payloadbuilder.api.catalog.Index.ColumnsType;
+import se.kuseman.payloadbuilder.api.catalog.Option;
+import se.kuseman.payloadbuilder.api.catalog.Schema;
+import se.kuseman.payloadbuilder.api.catalog.TableSchema;
+import se.kuseman.payloadbuilder.api.execution.IQuerySession;
+import se.kuseman.payloadbuilder.api.execution.ISeekPredicate;
+import se.kuseman.payloadbuilder.api.expression.IComparisonExpression;
+import se.kuseman.payloadbuilder.api.expression.IExpression;
+
+/**
+ * Catalog that supports HTTP requests
+ * 
+ * <pre>
+ * Works as a table that supports indices.
+ * 
+ * Endpoint is specified as the table source, if table source starts with http
+ * then the tablesource itself is considered to be the endpoint else the endpoint
+ * is taken from a catalog property with the same name. This to enable dynamic
+ * endpoints
+ * 
+ * Ex. 
+ * 
+ * from http#"http://path.to.endpoint" x
+ * 
+ * or
+ * 
+ * use http.endpoint = 'http://path.to.endpoint'
+ * from http#endpoint x
+ * 
+ * 
+ * A set of properties can be specified as table options to customize the request.
+ * Different place holders can be added in various pattern properties.
+ * - {{field}}     => This will enable 'field' as an indexed column which is intended to be used as pushdown predicates / index access
+ * 
+ * NOTE! A gotcha here is that the "field" MUST be present in the resulting payload else all predicates (where/join) will result in no hits.
+ *
+ * from http#"http://path/to/endpoint/v1" x with (
+ *   method = 'post',                                       // Method of HTTP request
+ *   header."Content-Type" = 'application/json',            // Headers to add. All qualifiers that has the first part = 'header' will be added
+ *   queryPattern = '/{{id}}?color={{color}}',              // Query pattern that contains place holders for index fields. Names between brackets will be eligable as index fields on table source
+ *   bodyPattern = '
+ *   {
+ *     "filter": {
+ *       "sizes": [{{size}}]
+ *     }
+ *   }'
+ * )
+ * 
+ * If there are any index fields in either query or body all those must be present as either
+ * seek predicate or push down predicate fields else a data source cannot be created
+ * 
+ * </pre>
+ */
+public class HttpCatalog extends Catalog
+{
+    public static final String NAME = "HttpCatalog";
+    static final String HEADER = "header";
+    static final String METHOD = "method";
+    static final String QUERY_PATTERN = "querypattern";
+    static final String BODY_PATTERN = "bodypattern";
+    static final String FAIL_ON_NON_200 = "failonnon200";
+    /** Placeholder regex */
+    static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{(.+?)\\}\\}");
+
+    private List<IResponseTransformer> responseTransformers;
+
+    public HttpCatalog()
+    {
+        this(List.of(new JsonResponseTransformer()));
+    }
+
+    public HttpCatalog(List<IResponseTransformer> responseTransformers)
+    {
+        super(NAME);
+        this.responseTransformers = requireNonNull(responseTransformers, "responseTransformers");
+        registerFunction(new QueryFunction(responseTransformers));
+    }
+
+    @Override
+    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
+    {
+        // Collect indices in options
+        Map<String, String> fields = new HashMap<>();
+        for (Option option : options)
+        {
+            String firstPart = option.getOption()
+                    .getFirst();
+            if (option.getOption()
+                    .size() == 1
+                    && (QUERY_PATTERN.equalsIgnoreCase(firstPart)
+                            || BODY_PATTERN.equalsIgnoreCase(firstPart)))
+            {
+                // Inspect value expression and find field place holders
+                // these will be our index columns
+                addIndexFields(fields, option.getValueExpression());
+            }
+        }
+
+        return new TableSchema(Schema.EMPTY, !fields.isEmpty() ? singletonList(new Index(table, new ArrayList<>(fields.values()), ColumnsType.ALL))
+                : emptyList());
+    }
+
+    @Override
+    public IDatasource getScanDataSource(IQuerySession session, String catalogAlias, QualifiedName table, DatasourceData data)
+    {
+        return getDataSource(session, catalogAlias, table, null, data);
+    }
+
+    @Override
+    public IDatasource getSeekDataSource(IQuerySession session, String catalogAlias, ISeekPredicate seekPredicate, DatasourceData data)
+    {
+        return getDataSource(session, catalogAlias, seekPredicate.getIndex()
+                .getTable(), seekPredicate, data);
+    }
+
+    private IDatasource getDataSource(IQuerySession session, String catalogAlias, QualifiedName table, ISeekPredicate seekPredicate, DatasourceData data)
+    {
+        if (table.size() != 1)
+        {
+            throw new CompileException("Tables qualifiers for " + NAME + " only supportes one part.");
+        }
+
+        Map<String, String> fields = new HashMap<>();
+        Request request = getRequest(session, data.getOptions(), data.getPredicates(), fields);
+        String endpoint = table.getFirst();
+        // Validate that we are indexing prefixed columns
+        // We can only make index request against GET/POST ones
+        if (seekPredicate != null)
+        {
+            // Remove the index columns from the placeholder fields
+            // This to determine if a data source can be created or not.
+            // If there are placeholders all of those must be satisfied either through index
+            // or push down predicates
+            for (String indexColumn : seekPredicate.getIndexColumns())
+            {
+                fields.remove(StringUtils.lowerCase(indexColumn));
+            }
+        }
+
+        if (!fields.isEmpty())
+        {
+            throw new CompileException("All request placeholders must be used. Placeholders not processed: " + fields.values());
+        }
+
+        return new HttpDataSource(catalogAlias, endpoint, seekPredicate, request, responseTransformers);
+    }
+
+    private void addIndexFields(Map<String, String> fields, IExpression expression)
+    {
+        String value = expression.toString();
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(value);
+        while (matcher.find())
+        {
+            String group = matcher.group(1);
+            fields.put(group.toLowerCase(), group);
+        }
+    }
+
+    private Request getRequest(IQuerySession session, List<Option> options, List<IPredicate> predicates, Map<String, String> fields)
+    {
+        List<Header> headers = new ArrayList<>();
+        IExpression method = null;
+        IExpression queryExpression = null;
+        IExpression bodyExpression = null;
+        IExpression contentType = null;
+
+        for (Option option : options)
+        {
+            QualifiedName qname = option.getOption();
+
+            if (qname.size() == 2
+                    && HEADER.equalsIgnoreCase(option.getOption()
+                            .getFirst()))
+            {
+                String headerName = option.getOption()
+                        .getParts()
+                        .get(1);
+
+                if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(headerName))
+                {
+                    contentType = option.getValueExpression();
+                }
+
+                headers.add(new Header(headerName, option.getValueExpression()));
+            }
+            else if (qname.size() == 1
+                    && METHOD.equalsIgnoreCase(qname.getFirst()))
+            {
+                method = option.getValueExpression();
+            }
+            else if (qname.size() == 1
+                    && QUERY_PATTERN.equalsIgnoreCase(qname.getFirst()))
+            {
+                queryExpression = option.getValueExpression();
+                addIndexFields(fields, option.getValueExpression());
+            }
+            else if (qname.size() == 1
+                    && BODY_PATTERN.equalsIgnoreCase(qname.getFirst()))
+            {
+                bodyExpression = option.getValueExpression();
+                addIndexFields(fields, option.getValueExpression());
+            }
+        }
+
+        // Collect push down predicates
+        List<Predicate> requestPredicates = new ArrayList<>();
+        Iterator<IPredicate> iterator = predicates.iterator();
+        while (iterator.hasNext())
+        {
+            IPredicate predicate = iterator.next();
+            Predicate requestPredicate = getPredicate(predicate, fields);
+            if (requestPredicate != null)
+            {
+                requestPredicates.add(requestPredicate);
+                iterator.remove();
+            }
+        }
+
+        return new Request(method, contentType, headers, queryExpression, bodyExpression, requestPredicates);
+    }
+
+    private Predicate getPredicate(IPredicate predicate, Map<String, String> singleValueIndices)
+    {
+        QualifiedName column = predicate.getQualifiedColumn();
+        if (column == null
+                || column.size() != 1)
+        {
+            return null;
+        }
+
+        String lowerColumn = column.getFirst()
+                .toLowerCase();
+        String indexColumn = singleValueIndices.get(lowerColumn);
+        if (indexColumn == null)
+        {
+            return null;
+        }
+
+        if (predicate.getType() == IPredicate.Type.COMPARISION
+                && predicate.getComparisonType() == IComparisonExpression.Type.EQUAL)
+        {
+            singleValueIndices.remove(lowerColumn);
+            return new Predicate(indexColumn, singletonList(predicate.getComparisonExpression()));
+        }
+        else if (predicate.getType() == IPredicate.Type.IN
+                && !predicate.getInExpression()
+                        .isNot())
+        {
+            singleValueIndices.remove(lowerColumn);
+            return new Predicate(indexColumn, predicate.getInExpression()
+                    .getArguments());
+        }
+        return null;
+    }
+
+    record Request(IExpression method, IExpression contentType, List<Header> headers, IExpression queryExpression, IExpression bodyExpression, List<Predicate> predicates)
+    {
+    }
+
+    record Predicate(String name, List<IExpression> values)
+    {
+    }
+
+    record Header(String name, IExpression expression)
+    {
+    }
+}

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/HttpDataSource.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/HttpDataSource.java
@@ -1,0 +1,317 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+
+import se.kuseman.payloadbuilder.api.QualifiedName;
+import se.kuseman.payloadbuilder.api.catalog.IDatasource;
+import se.kuseman.payloadbuilder.api.catalog.IDatasourceOptions;
+import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
+import se.kuseman.payloadbuilder.api.execution.ISeekPredicate;
+import se.kuseman.payloadbuilder.api.execution.ISeekPredicate.ISeekKey;
+import se.kuseman.payloadbuilder.api.execution.ISeekPredicate.SeekType;
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
+import se.kuseman.payloadbuilder.api.execution.ValueVector;
+import se.kuseman.payloadbuilder.api.expression.IExpression;
+import se.kuseman.payloadbuilder.catalog.http.HttpCatalog.Request;
+
+/** Data source impl. for Http catalog */
+@SuppressWarnings("deprecation")
+class HttpDataSource implements IDatasource
+{
+    static final String POST = "post";
+    static final String PUT = "put";
+    static final String PATCH = "patch";
+    static final String GET = "get";
+    private static final IResponseTransformer FALLBACK_TRANSFORMER = new FallbackResponseTransformer();
+    private final String catalogAlias;
+    private final String endpoint;
+    private final ISeekPredicate seekPredicate;
+    private final Request request;
+    private final List<IResponseTransformer> responseTransformers;
+
+    HttpDataSource(String catalogAlias, String endpoint, ISeekPredicate seekPredicate, Request request, List<IResponseTransformer> responseTransformers)
+    {
+        this.catalogAlias = requireNonNull(catalogAlias);
+        this.endpoint = requireNonNull(endpoint);
+        this.seekPredicate = seekPredicate;
+        this.request = requireNonNull(request);
+        this.responseTransformers = requireNonNull(responseTransformers);
+    }
+
+    @Override
+    public TupleIterator execute(IExecutionContext context, IDatasourceOptions options)
+    {
+        String endpoint = this.endpoint;
+        if (!StringUtils.startsWithIgnoreCase(endpoint, "http"))
+        {
+            endpoint = context.getSession()
+                    .getCatalogProperty(catalogAlias, endpoint)
+                    .valueAsString(0);
+            if (StringUtils.isAllBlank(endpoint))
+            {
+                throw new IllegalArgumentException("Missing catalog property '" + this.endpoint + "' for catalog alias: " + catalogAlias);
+            }
+        }
+
+        ValueVector vv = options.getOption(QualifiedName.of(HttpCatalog.FAIL_ON_NON_200), context);
+        boolean failOnNon200 = vv == null
+                || vv.isNull(0) ? true
+                        : vv.getBoolean(0);
+
+        HttpUriRequestBase request = getBaseRequest(context, endpoint);
+        addHeaders(request, context);
+        return execute(request, responseTransformers, failOnNon200);
+    }
+
+    static TupleIterator execute(HttpUriRequestBase request, List<IResponseTransformer> responseTransformers, boolean failOnNon200)
+    {
+        CloseableHttpClient client = HttpClients.custom()
+                .build();
+
+        try
+        {
+            return client.execute(request, new HttpClientResponseHandler<TupleIterator>()
+            {
+                @Override
+                public TupleIterator handleResponse(ClassicHttpResponse response) throws HttpException, IOException
+                {
+                    if (response.getCode() != 200)
+                    {
+                        if (!failOnNon200)
+                        {
+                            return TupleIterator.EMPTY;
+                        }
+
+                        String error = IOUtils.toString(response.getEntity()
+                                .getContent(), StandardCharsets.UTF_8);
+                        throw new RuntimeException("Response was non 200. Code: " + response.getCode() + ", body: " + error);
+                    }
+
+                    for (IResponseTransformer transformer : responseTransformers)
+                    {
+                        if (transformer.canHandle(request, response))
+                        {
+                            return transformer.transform(request, response);
+                        }
+                    }
+
+                    return FALLBACK_TRANSFORMER.transform(request, response);
+                }
+            });
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error performing HTTP request", e);
+        }
+    }
+
+    private HttpUriRequestBase getBaseRequest(IExecutionContext context, String baseEndpoint)
+    {
+        String method;
+        if (request.method() == null)
+        {
+            method = GET;
+        }
+        else
+        {
+            method = Objects.toString(request.method()
+                    .eval(context)
+                    .valueAsString(0), GET);
+        }
+
+        String endpoint = baseEndpoint;
+
+        // Gather place holder values
+        Map<String, List<Object>> replaceValues = new HashMap<>();
+
+        // Predicates
+        if (!request.predicates()
+                .isEmpty())
+        {
+            for (HttpCatalog.Predicate p : request.predicates())
+            {
+                replaceValues.put(p.name(), evalPredicate(context, p.values()));
+            }
+        }
+
+        // .. seek predicate
+        if (seekPredicate != null)
+        {
+            List<ISeekKey> keys = seekPredicate.getSeekKeys(context);
+            int size = keys.size();
+            for (int i = 0; i < size; i++)
+            {
+                ISeekKey key = keys.get(i);
+                if (key.getType() != SeekType.EQ)
+                {
+                    throw new IllegalArgumentException(HttpCatalog.NAME + " only supports EQ seek keys");
+                }
+
+                String column = seekPredicate.getIndexColumns()
+                        .get(i);
+                List<Object> values = new ArrayList<>();
+                ValueVector vectorValues = key.getValue();
+                int vsize = vectorValues.size();
+                for (int v = 0; v < vsize; v++)
+                {
+                    Object value = vectorValues.valueAsObject(v);
+                    values.add(value);
+                }
+
+                replaceValues.compute(column, (k, v) ->
+                {
+                    if (v == null)
+                    {
+                        return values;
+                    }
+
+                    v.addAll(values);
+                    return v;
+                });
+            }
+        }
+
+        // Replace query expression
+        if (request.queryExpression() != null)
+        {
+            String queryPart = request.queryExpression()
+                    .eval(context)
+                    .valueAsString(0);
+
+            if (!replaceValues.isEmpty())
+            {
+                StringBuilder sb = new StringBuilder(queryPart.length() * 2);
+                Matcher matcher = HttpCatalog.PLACEHOLDER_PATTERN.matcher(queryPart);
+                while (matcher.find())
+                {
+                    List<Object> list = replaceValues.get(matcher.group(1));
+                    String replaceValue = list.stream()
+                            .filter(Objects::nonNull)
+                            .map(String::valueOf)
+                            .map(v -> URLEncoder.encode(v, StandardCharsets.UTF_8))
+                            .collect(joining(","));
+                    matcher.appendReplacement(sb, replaceValue);
+                }
+                matcher.appendTail(sb);
+                endpoint += sb.toString();
+            }
+        }
+
+        HttpUriRequestBase httpRequest = getRequestBase(method, endpoint);
+
+        // Process body expression
+        if (request.bodyExpression() != null)
+        {
+            ContentType contentType = ContentType.APPLICATION_JSON;
+            if (request.contentType() != null)
+            {
+                contentType = ContentType.parseLenient(request.contentType()
+                        .eval(context)
+                        .valueAsString(0));
+            }
+            // TODO: request body builder abstraction, escape strings, append items
+            // ie.
+            // xml -> <field>value1</field><field>value2</field>
+            // json -> "value1","value2"
+            // For now we only support json
+            if (!ContentType.APPLICATION_JSON.isSameMimeType(contentType))
+            {
+                throw new IllegalArgumentException("Only application/json Content-Type is supported");
+            }
+
+            String body = request.bodyExpression()
+                    .eval(context)
+                    .valueAsString(0);
+
+            if (!replaceValues.isEmpty())
+            {
+                StringBuilder sb = new StringBuilder(body.length() * 2);
+                Matcher matcher = HttpCatalog.PLACEHOLDER_PATTERN.matcher(body);
+                while (matcher.find())
+                {
+                    List<Object> list = replaceValues.get(matcher.group(1));
+                    String replaceValue = list.stream()
+                            .filter(Objects::nonNull)
+                            .map(v ->
+                            {
+                                if (v instanceof Number)
+                                {
+                                    return String.valueOf(v);
+                                }
+
+                                return "\"" + StringEscapeUtils.escapeJson(String.valueOf(v))
+                                        .replace("\\", "\\\\")
+                                       + "\"";
+                            })
+                            .collect(joining(","));
+                    matcher.appendReplacement(sb, replaceValue);
+                }
+                matcher.appendTail(sb);
+                body = sb.toString();
+            }
+
+            httpRequest.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
+        }
+
+        return httpRequest;
+    }
+
+    static HttpUriRequestBase getRequestBase(String method, String endpoint)
+    {
+        HttpUriRequestBase httpRequest = switch (method.toLowerCase())
+        {
+            case GET -> new HttpGet(endpoint);
+            case POST -> new HttpPost(endpoint);
+            case PUT -> new HttpPut(endpoint);
+            case PATCH -> new HttpPatch(endpoint);
+            default -> throw new IllegalArgumentException("Unsupported request method '" + method + "'");
+        };
+        return httpRequest;
+    }
+
+    private void addHeaders(HttpUriRequestBase httpRequest, IExecutionContext context)
+    {
+        for (HttpCatalog.Header header : request.headers())
+        {
+            String value = header.expression()
+                    .eval(context)
+                    .valueAsString(0);
+            httpRequest.addHeader(header.name(), value);
+        }
+    }
+
+    private List<Object> evalPredicate(IExecutionContext context, List<IExpression> expressions)
+    {
+        return expressions.stream()
+                .map(e -> e.eval(context)
+                        .valueAsObject(0))
+                .toList();
+    }
+}

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/IResponseTransformer.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/IResponseTransformer.java
@@ -1,0 +1,16 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
+
+/** Transformer that transforms a http response into a tuple iterator */
+public interface IResponseTransformer
+{
+    /** Returns true if this transformer can handle provided request/response. */
+    boolean canHandle(HttpUriRequestBase request, ClassicHttpResponse response);
+
+    /** Transform provided request/response to a {@link TupleIterator}. */
+    TupleIterator transform(HttpUriRequestBase request, ClassicHttpResponse response);
+}

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/JsonResponseTransformer.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/JsonResponseTransformer.java
@@ -1,0 +1,112 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import se.kuseman.payloadbuilder.api.catalog.Column;
+import se.kuseman.payloadbuilder.api.catalog.Column.Type;
+import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
+import se.kuseman.payloadbuilder.api.catalog.Schema;
+import se.kuseman.payloadbuilder.api.execution.ObjectTupleVector;
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
+import se.kuseman.payloadbuilder.api.execution.TupleVector;
+
+/** Transformer that transforms JSON responses */
+public class JsonResponseTransformer implements IResponseTransformer
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public boolean canHandle(HttpUriRequestBase request, ClassicHttpResponse response)
+    {
+        // First prio => check the response content type
+        Header header = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
+        if (header != null
+                && ContentType.APPLICATION_JSON.isSameMimeType(ContentType.parseLenient(header.getValue())))
+        {
+            return true;
+        }
+
+        // Second prio => See if the request contains an Accept for JSON
+        header = request.getFirstHeader(HttpHeaders.ACCEPT);
+        if (header != null
+                && ContentType.APPLICATION_JSON.isSameMimeType(ContentType.parseLenient(header.getValue())))
+        {
+            return true;
+        }
+
+        // This is probably not a JSON response
+        return false;
+    }
+
+    @Override
+    public TupleIterator transform(HttpUriRequestBase request, ClassicHttpResponse response)
+    {
+        try
+        {
+            Object value = MAPPER.readValue(response.getEntity()
+                    .getContent(), Object.class);
+            if (value == null)
+            {
+                return TupleIterator.EMPTY;
+            }
+            return TupleIterator.singleton(convertToTupleVector(value));
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error transforming JSON into a TupleIterator", e);
+        }
+
+    }
+
+    /** Convert response value to a {@link TupleVector} */
+    @SuppressWarnings("unchecked")
+    private static TupleVector convertToTupleVector(final Object value)
+    {
+        requireNonNull(value);
+        List<Map<String, Object>> maps;
+
+        if (value instanceof Map)
+        {
+            maps = singletonList((Map<String, Object>) value);
+        }
+        else if (value instanceof List)
+        {
+            maps = (List<Map<String, Object>>) value;
+        }
+        else
+        {
+            throw new IllegalAccessError("Cannot convert value " + value + " to a TupleVector");
+        }
+
+        List<String> columns = maps.stream()
+                .flatMap(m -> m.keySet()
+                        .stream())
+                .distinct()
+                .collect(toList());
+
+        final Schema schema = new Schema(columns.stream()
+                .map(c -> new Column(c, ResolvedType.of(Type.Any)))
+                .toList());
+
+        return new ObjectTupleVector(schema, maps.size(), (row, column) ->
+        {
+            String columnName = columns.get(column);
+            return maps.get(row)
+                    .get(columnName);
+        });
+    }
+}

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/QueryFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/QueryFunction.java
@@ -1,0 +1,114 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+
+import se.kuseman.payloadbuilder.api.QualifiedName;
+import se.kuseman.payloadbuilder.api.catalog.IDatasourceOptions;
+import se.kuseman.payloadbuilder.api.catalog.Option;
+import se.kuseman.payloadbuilder.api.catalog.Schema;
+import se.kuseman.payloadbuilder.api.catalog.TableFunctionInfo;
+import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
+import se.kuseman.payloadbuilder.api.execution.ValueVector;
+import se.kuseman.payloadbuilder.api.expression.IExpression;
+
+/** TVF for http query to be able to cross/outer apply http calls */
+class QueryFunction extends TableFunctionInfo
+{
+    static final String BODY = "body";
+    private final List<IResponseTransformer> responseTransformers;
+
+    QueryFunction(List<IResponseTransformer> responseTransformers)
+    {
+        super("query");
+        this.responseTransformers = responseTransformers;
+    }
+
+    @Override
+    public Arity arity()
+    {
+        return Arity.ONE;
+    }
+
+    @Override
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, IDatasourceOptions options)
+    {
+        /*
+         * @formatter:off
+         * from http#query(`http://www.service.se/${countryCode}/items`) x with
+         * (
+         * method = 'POST',
+         * body = `{ "country": "${@countryCode}" }`,
+         * header."x-custom" = 'some header'
+         * )
+         * @formatter:on
+         */
+
+        ValueVector vv;
+
+        vv = arguments.get(0)
+                .eval(context);
+        String endpoint = vv.isNull(0) ? null
+                : vv.getString(0)
+                        .toString();
+        if (isBlank(endpoint))
+        {
+            throw new IllegalArgumentException("endpoint must be a non null string value");
+        }
+
+        vv = options.getOption(QualifiedName.of(HttpCatalog.METHOD), context);
+
+        String method = vv == null
+                || vv.isNull(0) ? HttpDataSource.GET
+                        : vv.getString(0)
+                                .toString()
+                                .toLowerCase();
+
+        vv = options.getOption(QualifiedName.of(BODY), context);
+
+        String body = vv == null
+                || vv.isNull(0) ? null
+                        : vv.getString(0)
+                                .toString();
+
+        HttpUriRequestBase httpRequest = HttpDataSource.getRequestBase(method, endpoint);
+
+        if (body != null)
+        {
+            httpRequest.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
+        }
+
+        boolean failOnNon200 = true;
+
+        for (Option option : options.getOptions())
+        {
+            QualifiedName name = option.getOption();
+            if (name.size() == 2
+                    && HttpCatalog.HEADER.equalsIgnoreCase(name.getFirst()))
+            {
+                String value = option.getValueExpression()
+                        .eval(context)
+                        .valueAsString(0);
+                httpRequest.addHeader(name.getParts()
+                        .get(1), value);
+            }
+            else if (name.size() == 1
+                    && HttpCatalog.FAIL_ON_NON_200.equalsIgnoreCase(name.getFirst()))
+            {
+                vv = option.getValueExpression()
+                        .eval(context);
+                failOnNon200 = vv.isNull(0) ? true
+                        : vv.getBoolean(0);
+            }
+        }
+
+        return HttpDataSource.execute(httpRequest, responseTransformers, failOnNon200);
+    }
+}

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/JdbcCatalog.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/JdbcCatalog.java
@@ -28,6 +28,7 @@ import se.kuseman.payloadbuilder.api.catalog.IPredicate;
 import se.kuseman.payloadbuilder.api.catalog.ISortItem;
 import se.kuseman.payloadbuilder.api.catalog.ISortItem.NullOrder;
 import se.kuseman.payloadbuilder.api.catalog.Index;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableSchema;
 import se.kuseman.payloadbuilder.api.execution.IQuerySession;
@@ -59,7 +60,7 @@ public class JdbcCatalog extends Catalog
     }
 
     @Override
-    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
     {
         return new TableSchema(Schema.EMPTY, singletonList(new Index(table, emptyList(), Index.ColumnsType.WILDCARD)));
     }

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/es/BaseESTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/es/BaseESTest.java
@@ -1417,7 +1417,7 @@ abstract class BaseESTest extends Assert
         QualifiedName table = QualifiedName.of(version.getStrategy()
                 .supportsTypes() ? type
                         : ESCatalog.SINGLE_TYPE_TABLE_NAME);
-        TableSchema tableSchema = catalog.getTableSchema(context.getSession(), CATALOG_ALIAS, table);
+        TableSchema tableSchema = catalog.getTableSchema(context.getSession(), CATALOG_ALIAS, table, emptyList());
         Index index = tableSchema.getIndices()
                 .stream()
                 .filter(i -> i.getColumns()

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/http/HttpCatalogTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/http/HttpCatalogTest.java
@@ -1,0 +1,682 @@
+package se.kuseman.payloadbuilder.catalog.http;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static se.kuseman.payloadbuilder.test.VectorTestUtils.vv;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.mock.Expectation;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+import se.kuseman.payloadbuilder.api.QualifiedName;
+import se.kuseman.payloadbuilder.api.catalog.Column;
+import se.kuseman.payloadbuilder.api.catalog.Column.Type;
+import se.kuseman.payloadbuilder.api.catalog.CompileException;
+import se.kuseman.payloadbuilder.api.catalog.DatasourceData;
+import se.kuseman.payloadbuilder.api.catalog.FunctionInfo.Arity;
+import se.kuseman.payloadbuilder.api.catalog.IDatasource;
+import se.kuseman.payloadbuilder.api.catalog.IDatasourceOptions;
+import se.kuseman.payloadbuilder.api.catalog.IPredicate;
+import se.kuseman.payloadbuilder.api.catalog.Index;
+import se.kuseman.payloadbuilder.api.catalog.Index.ColumnsType;
+import se.kuseman.payloadbuilder.api.catalog.Option;
+import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
+import se.kuseman.payloadbuilder.api.catalog.Schema;
+import se.kuseman.payloadbuilder.api.catalog.TableFunctionInfo;
+import se.kuseman.payloadbuilder.api.catalog.TableSchema;
+import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
+import se.kuseman.payloadbuilder.api.execution.ISeekPredicate;
+import se.kuseman.payloadbuilder.api.execution.ISeekPredicate.SeekType;
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
+import se.kuseman.payloadbuilder.api.execution.TupleVector;
+import se.kuseman.payloadbuilder.api.execution.ValueVector;
+import se.kuseman.payloadbuilder.api.expression.ILiteralStringExpression;
+import se.kuseman.payloadbuilder.catalog.TestUtils;
+import se.kuseman.payloadbuilder.test.ExpressionTestUtils;
+import se.kuseman.payloadbuilder.test.IPredicateMock;
+import se.kuseman.payloadbuilder.test.VectorTestUtils;
+
+/** Test of {@link HttpCatalog} */
+public class HttpCatalogTest
+{
+    private HttpCatalog catalog = new HttpCatalog();
+    private ClientAndServer mockServer;
+
+    @Before
+    public void startMockServer()
+    {
+        mockServer = startClientAndServer();
+    }
+
+    @After
+    public void stopMockServer()
+    {
+        mockServer.stop();
+    }
+
+    @Test
+    public void test_getTableSchema()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        QualifiedName table = QualifiedName.of("http://www.service.com/");
+        TableSchema actual;
+        // No place holders
+        actual = catalog.getTableSchema(context.getSession(), "http", table, emptyList());
+        assertEquals(new TableSchema(Schema.EMPTY, emptyList()), actual);
+
+        // Query
+        actual = catalog.getTableSchema(context.getSession(), "http", table, List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}"))));
+        assertEquals(new TableSchema(Schema.EMPTY, List.of(new Index(table, asList("id"), ColumnsType.ALL))), actual);
+
+        // Body
+        actual = catalog.getTableSchema(context.getSession(), "http", table,
+                List.of(new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression("{ \"keys\": [{{bodyId}}] }"))));
+        assertEquals(new TableSchema(Schema.EMPTY, List.of(new Index(table, asList("bodyId"), ColumnsType.ALL))), actual);
+
+        // Query + body
+        actual = catalog.getTableSchema(context.getSession(), "http", table, List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}")),
+                new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression("{ \"keys\": [{{bodyId}}] }"))));
+        assertEquals(new TableSchema(Schema.EMPTY, List.of(new Index(table, asList("id", "bodyId"), ColumnsType.ALL))), actual);
+    }
+
+    @Test
+    public void test_getSeekDataSource_get()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}"))));
+
+        QualifiedName table = QualifiedName.of("http://localhost:" + mockServer.getPort());
+
+        ISeekPredicate seekPrecidate = mockSeekPrecidate(context, table, asList("id"), List.<Object[]>of(new Object[] { 123, 456 }));
+
+        IDatasource dataSource = catalog.getSeekDataSource(context.getSession(), "http", seekPrecidate, data);
+
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/123,456")
+                .withMethod("get"))
+                .respond(HttpResponse.response("{\"key\":123}")
+                        .withHeader("Content-Type", "application/json"));
+
+        TupleIterator it = dataSource.execute(context, TestUtils.mockOptions(500));
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any)), List.of(
+                    vv(Type.Any, 123)
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getSeekDataSource_post()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("post")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression("{\"keys\":[{{id}}]}"))));
+
+        QualifiedName table = QualifiedName.of("http://localhost:" + mockServer.getPort());
+
+        ISeekPredicate seekPrecidate = mockSeekPrecidate(context, table, asList("id"), List.<Object[]>of(new Object[] { 123, 456 }));
+
+        IDatasource dataSource = catalog.getSeekDataSource(context.getSession(), "http", seekPrecidate, data);
+
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("post")
+                .withBody("{\"keys\":[123,456]}"))
+                .respond(HttpResponse.response("{\"key\":123}")
+                        .withHeader("Content-Type", "application/json"));
+
+        TupleIterator it = dataSource.execute(context, TestUtils.mockOptions(500));
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any)), List.of(
+                    vv(Type.Any, 123)
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getSeekDataSource_post_strings()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("post")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression("{\"keys\":[{{id}}]}"))));
+
+        QualifiedName table = QualifiedName.of("http://localhost:" + mockServer.getPort());
+
+        ISeekPredicate seekPrecidate = mockSeekPrecidate(context, table, asList("id"), List.<Object[]>of(new Object[] { "value", " value \" with % etc." }));
+
+        IDatasource dataSource = catalog.getSeekDataSource(context.getSession(), "http", seekPrecidate, data);
+
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("post")
+                .withBody("{\"keys\":[\"value\",\" value \\\" with % etc.\"]}"))
+                .respond(HttpResponse.response("{\"key\":123}")
+                        .withHeader("Content-Type", "application/json"));
+
+        TupleIterator it = dataSource.execute(context, TestUtils.mockOptions(500));
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any)), List.of(
+                    vv(Type.Any, 123)
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_invalid_table_name()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}"))));
+
+        try
+        {
+            catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http:", "//localhost:" + mockServer.getPort()), data);
+        }
+        catch (CompileException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Tables qualifiers for HttpCatalog only supportes one part."));
+        }
+    }
+
+    @Test
+    public void test_getScanDataSource_eq_predicate()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+
+        List<IPredicate> predicates = new ArrayList<>(List.of(IPredicateMock.eq("id", "id_value"), IPredicateMock.eq("id2", "value2")));
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), predicates, emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}"))));
+
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost:" + mockServer.getPort()), data);
+
+        assertEquals("predicate for 'id' column should be consumed", 1, predicates.size());
+
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/id_value")
+                .withMethod("get"))
+                .respond(HttpResponse.response("{\"key\":123}")
+                        .withHeader("Content-Type", "application/json"));
+
+        TupleIterator it = dataSource.execute(context, TestUtils.mockOptions(500));
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any)), List.of(
+                    vv(Type.Any, 123)
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_in_predicate()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+
+        List<IPredicate> predicates = new ArrayList<>(List.of(IPredicateMock.in("id", List.of("value1", " value2")), IPredicateMock.eq("id2", "value2")));
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), predicates, emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}"))));
+
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost:" + mockServer.getPort()), data);
+
+        assertEquals("predicate for 'id' column should be consumed", 1, predicates.size());
+
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/value1,+value2")
+                .withMethod("get"))
+                .respond(HttpResponse.response("{\"key\":123}")
+                        .withHeader("Content-Type", "application/json"));
+
+        TupleIterator it = dataSource.execute(context, TestUtils.mockOptions(500));
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any)), List.of(
+                    vv(Type.Any, 123)
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_predicate_not_supported_predicate()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+
+        List<IPredicate> predicates = new ArrayList<>(List.of(IPredicateMock.notIn("id", List.of("value1", " value2")), IPredicateMock.eq("id2", "value2")));
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), predicates, emptyList(), emptyList(),
+                List.of(new Option(QualifiedName.of(HttpCatalog.QUERY_PATTERN), ExpressionTestUtils.createStringExpression("/{{id}}"))));
+
+        try
+        {
+            catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost:" + mockServer.getPort()), data);
+        }
+        catch (CompileException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("All request placeholders must be used. Placeholders not processed: [id]"));
+        }
+    }
+
+    @Test
+    public void test_query_null_endpoint()
+    {
+        TableFunctionInfo function = catalog.getTableFunction("query");
+        assertEquals(Arity.ONE, function.arity());
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        try
+        {
+            function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createNullExpression()), options);
+            fail("Should fail");
+        }
+        catch (IllegalArgumentException e)
+        {
+            e.printStackTrace();
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("endpoint must be a non null string value"));
+        }
+    }
+
+    @Test
+    public void test_query_function_fallback_response_transformer()
+    {
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("get"))
+                .respond(HttpResponse.response("some arbitrary body")
+                        .withHeader("custom-header", "value1", "value2"));
+
+        TableFunctionInfo function = catalog.getTableFunction("query");
+        assertEquals(Arity.ONE, function.arity());
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), options);
+
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(FallbackResponseTransformer.SCHEMA, List.of(
+                    vv(Type.String, "some arbitrary body"),
+                    vv(ResolvedType.table(FallbackResponseTransformer.HEADERS_SCHEMA), TupleVector.of(FallbackResponseTransformer.HEADERS_SCHEMA, List.of(
+                            vv(Type.String, "custom-header", "custom-header", "connection", "content-length"),
+                            vv(Type.String, "value1", "value2", "keep-alive", "19")
+                            )))
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_query_function_non_200()
+    {
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("get"))
+                .respond(HttpResponse.notFoundResponse()
+                        .withBody("error error")
+                        .withHeader("custom-header", "value1", "value2"));
+
+        TableFunctionInfo function = catalog.getTableFunction("query");
+        assertEquals(Arity.ONE, function.arity());
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        try
+        {
+            function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), options);
+            fail("Should fail");
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Response was non 200. Code: 404, body: error error"));
+        }
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_query_function_non_200_dont_fail()
+    {
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("get"))
+                .respond(HttpResponse.notFoundResponse()
+                        .withBody("error error")
+                        .withHeader("custom-header", "value1", "value2"));
+
+        TableFunctionInfo function = catalog.getTableFunction("query");
+        assertEquals(Arity.ONE, function.arity());
+
+        ILiteralStringExpression failOnNon200 = ExpressionTestUtils.createStringExpression("false");
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        IDatasourceOptions options = Mockito.mock(IDatasourceOptions.class);
+        Mockito.when(options.getOptions())
+                .thenReturn(List.of(new Option(QualifiedName.of(HttpCatalog.FAIL_ON_NON_200), failOnNon200)));
+
+        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), options);
+        assertFalse(it.hasNext());
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_query_function_json_response_transformer()
+    {
+        String body = "{\"json\":\"value\"}";
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/api")
+                .withMethod("post")
+                .withHeader("x-header", "custom-value")
+                .withBody(body))
+                .respond(HttpResponse.response("[{ \"key\": 123 }, { \"key2\": 456 }]")
+                        .withHeader("custom-header", "value5", "value5")
+                        .withHeader("Content-Type", "application/json"));
+
+        TableFunctionInfo function = catalog.getTableFunction("query");
+
+        ILiteralStringExpression x_header_expression = ExpressionTestUtils.createStringExpression("custom-value");
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+        IDatasourceOptions options = Mockito.mock(IDatasourceOptions.class);
+        Mockito.when(options.getOption(QualifiedName.of(HttpCatalog.METHOD), context))
+                .thenReturn(vv(Type.String, HttpDataSource.POST));
+        Mockito.when(options.getOption(QualifiedName.of(QueryFunction.BODY), context))
+                .thenReturn(vv(Type.String, body));
+        Mockito.when(options.getOptions())
+                .thenReturn(List.of(new Option(QualifiedName.of(HttpCatalog.HEADER, "x-header"), x_header_expression)));
+
+        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort() + "/api")), options);
+
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any), Column.of("key2", Type.Any)), List.of(
+                    vv(Type.Any, 123, null),
+                    vv(Type.Any, null, 456)
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(2, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_with_no_placeholders()
+    {
+        String body = "{\"json\":\"value\"}";
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("put")
+                .withBody(body)
+                .withHeader("x-header", "x-value"))
+                .respond(HttpResponse.response("{ \"key\": \"hello world\" }")
+                        .withHeader("Content-Type", "application/json"));
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                asList(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("put")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression(body)),
+                        new Option(QualifiedName.of(HttpCatalog.HEADER, "x-header"), ExpressionTestUtils.createStringExpression("x-value"))));
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost:" + mockServer.getPort()), data);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        TupleIterator it = dataSource.execute(context, options);
+
+        int rowCount = 0;
+        while (it.hasNext())
+        {
+            TupleVector v = it.next();
+
+            //@formatter:off
+            VectorTestUtils.assertTupleVectorsEquals(TupleVector.of(Schema.of(Column.of("key", Type.Any)), List.of(
+                    vv(Type.Any, "hello world")
+                    ))
+                    , v);
+            //@formatter:on
+            rowCount += v.getRowCount();
+        }
+        assertEquals(1, rowCount);
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_with_no_placeholders_non_200_repsonse_code()
+    {
+        String body = "{\"json\":\"value\"}";
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("patch")
+                .withBody(body)
+                .withHeader("x-header", "x-value"))
+                .respond(HttpResponse.notFoundResponse()
+                        .withBody("some error"));
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                asList(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("patch")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression(body)),
+                        new Option(QualifiedName.of(HttpCatalog.HEADER, "x-header"), ExpressionTestUtils.createStringExpression("x-value"))));
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost:" + mockServer.getPort()), data);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        try
+        {
+            dataSource.execute(context, options);
+            fail("Should fail");
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Response was non 200. Code: 404, body: some error"));
+        }
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_with_no_placeholders_non_200_repsonse_code_dont_fail()
+    {
+        String body = "{\"json\":\"value\"}";
+        Expectation[] mocks = mockServer.when(HttpRequest.request("/")
+                .withMethod("patch")
+                .withBody(body)
+                .withHeader("x-header", "x-value"))
+                .respond(HttpResponse.notFoundResponse()
+                        .withBody("some error"));
+
+        IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                asList(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("patch")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression(body)),
+                        new Option(QualifiedName.of(HttpCatalog.HEADER, "x-header"), ExpressionTestUtils.createStringExpression("x-value"))));
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost:" + mockServer.getPort()), data);
+        IDatasourceOptions options = Mockito.mock(IDatasourceOptions.class);
+        Mockito.when(options.getOption(QualifiedName.of(HttpCatalog.FAIL_ON_NON_200), context))
+                .thenReturn(vv(Type.Boolean, false));
+
+        TupleIterator it = dataSource.execute(context, options);
+        assertFalse(it.hasNext());
+
+        mockServer.verify(mocks[0].getId());
+    }
+
+    @Test
+    public void test_getScanDataSource_with_no_placeholders_missing_endpoint_catalog_property()
+    {
+        String body = "{\"json\":\"value\"}";
+        IExecutionContext context = TestUtils.mockExecutionContext("http", Map.of(), 0, null);
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                asList(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("put")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression(body)),
+                        new Option(QualifiedName.of(HttpCatalog.HEADER, "Content-Type"), ExpressionTestUtils.createStringExpression("text/plain"))));
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("endpoint"), data);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        try
+        {
+            dataSource.execute(context, options);
+            fail("Should fail");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Missing catalog property 'endpoint' for catalog alias: http"));
+        }
+    }
+
+    @Test
+    public void test_getScanDataSource_with_no_placeholders_unsupported_method()
+    {
+        IExecutionContext context = TestUtils.mockExecutionContext("http", Map.of(), 0, null);
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                asList(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("option"))));
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("http://localhost"), data);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        try
+        {
+            dataSource.execute(context, options);
+            fail("Should fail");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Unsupported request method 'option'"));
+        }
+    }
+
+    @Test
+    public void test_getScanDataSource_with_no_placeholders_unsupported_content_type()
+    {
+        String body = "{\"json\":\"value\"}";
+        IExecutionContext context = TestUtils.mockExecutionContext("http", Map.of("endpoint", "http://localhost"), 0, null);
+
+        DatasourceData data = new DatasourceData(0, Optional.empty(), emptyList(), emptyList(), emptyList(),
+                asList(new Option(QualifiedName.of(HttpCatalog.METHOD), ExpressionTestUtils.createStringExpression("put")),
+                        new Option(QualifiedName.of(HttpCatalog.BODY_PATTERN), ExpressionTestUtils.createStringExpression(body)),
+                        new Option(QualifiedName.of(HttpCatalog.HEADER, "Content-Type"), ExpressionTestUtils.createStringExpression("text/plain"))));
+        IDatasource dataSource = catalog.getScanDataSource(context.getSession(), "http", QualifiedName.of("endpoint"), data);
+        IDatasourceOptions options = TestUtils.mockOptions(500);
+
+        try
+        {
+            dataSource.execute(context, options);
+            fail("Should fail");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Only application/json Content-Type is supported"));
+        }
+    }
+
+    private ISeekPredicate mockSeekPrecidate(IExecutionContext context, QualifiedName table, List<String> columns, List<Object[]> values)
+    {
+        Index index = new Index(table, columns, ColumnsType.ALL);
+        ISeekPredicate seekPredicate = mock(ISeekPredicate.class);
+        when(seekPredicate.getIndex()).thenReturn(index);
+        when(seekPredicate.getIndexColumns()).thenReturn(columns);
+
+        int size = columns.size();
+        List<ISeekPredicate.ISeekKey> seekKeys = new ArrayList<>(size);
+        for (int i = 0; i < size; i++)
+        {
+            ISeekPredicate.ISeekKey seekKey = mock(ISeekPredicate.ISeekKey.class);
+            seekKeys.add(seekKey);
+            when(seekKey.getType()).thenReturn(SeekType.EQ);
+            when(seekKey.getValue()).thenReturn(ValueVector.literalAny(values.get(i)));
+        }
+        when(seekPredicate.getSeekKeys(any(IExecutionContext.class))).thenReturn(seekKeys);
+        return seekPredicate;
+    }
+}

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/jdbc/BaseJDBCTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/jdbc/BaseJDBCTest.java
@@ -458,7 +458,7 @@ abstract class BaseJDBCTest extends Assert
     {
         // Fetch indices and extract the one on key field
         QualifiedName table = QualifiedName.of(TEST_TABLE);
-        TableSchema tableSchema = catalog.getTableSchema(context.getSession(), CATALOG_ALIAS, table);
+        TableSchema tableSchema = catalog.getTableSchema(context.getSession(), CATALOG_ALIAS, table, emptyList());
         Index index = tableSchema.getIndices()
                 .get(0);
 

--- a/payloadbuilder-core/pom.xml
+++ b/payloadbuilder-core/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>se.kuseman.payloadbuilder</groupId>
             <artifactId>payloadbuilder-api</artifactId>
-               <version>${project.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- External -->
         <dependency>

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/SystemCatalog.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/SystemCatalog.java
@@ -18,6 +18,7 @@ import se.kuseman.payloadbuilder.api.catalog.Column;
 import se.kuseman.payloadbuilder.api.catalog.DatasourceData;
 import se.kuseman.payloadbuilder.api.catalog.IDatasource;
 import se.kuseman.payloadbuilder.api.catalog.IDatasourceOptions;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableSchema;
@@ -446,7 +447,7 @@ public class SystemCatalog extends Catalog
     }
 
     @Override
-    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+    public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
     {
         int size = table.size();
         QuerySession querySession = (QuerySession) session;

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/execution/ExpressionMath.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/execution/ExpressionMath.java
@@ -28,6 +28,11 @@ public final class ExpressionMath
         requireNonNull(left);
         requireNonNull(right);
 
+        if (left == right)
+        {
+            return 0;
+        }
+
         ValueVector leftLiteral = getLiteral(left);
         ValueVector rightLiteral = getLiteral(right);
 

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/execution/TemporaryTable.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/execution/TemporaryTable.java
@@ -47,6 +47,11 @@ public class TemporaryTable
         return vector;
     }
 
+    public List<Index> getIndices()
+    {
+        return indices;
+    }
+
     /** Return a tuple iterator from this temporary table by provided index */
     public TupleIterator getIndexIterator(IExecutionContext context, ISeekPredicate seekPredicate)
     {

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/LikeExpression.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/LikeExpression.java
@@ -126,8 +126,11 @@ public class LikeExpression implements ILikeExpression, Invertable
 
             String matchValue = String.valueOf(value.getString(i));
 
-            builder.put(currentPattern.matcher(matchValue)
-                    .find());
+            boolean result = currentPattern.matcher(matchValue)
+                    .find();
+
+            builder.put(not ? !result
+                    : result);
         }
         return builder.build();
     }

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/PredicatePushDown.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/PredicatePushDown.java
@@ -60,9 +60,32 @@ class PredicatePushDown extends ALogicalPlanOptimizer<PredicatePushDown.Ctx>
     static class Ctx extends ALogicalPlanOptimizer.Context
     {
         /**
-         * Flag that is set to indicate if null predicates can be extracted or not. Ie. A WHERE with a null predicate cannot be pushed down when using LEFT JOIN etc.
+         * <pre>
+         * Set with constrained table sources that is used to limit which table sources
+         * that can extract predicates. For example we don't want to push a WHERE into a LEFT JOIN
+         * Ie.
+         *
+         *  select *
+         *  from tableA A
+         *  left join tableB b
+         *   on a.col = b.col
+         *   and a.value = 1         <-- Cannot push down to tableA a
+         *   and b.value = 1         <-- Can push down to tableB b
+         *  where b.field = 1        <-- Cannot push down to tableB b
+         *
+         *  1. Where
+         *     Extract b.field = 1 with constraint: None
+         *  2. Join (Left => constrain predicates to all inner table sources)
+         *     Extract a.vlaue = 1 with constraint: tableB
+         *     Extract b.value = 1 with constraint: tableB
+         *     Set constrainedTableSources to tableB
+         *  4. Create tableA
+         *     Fetch predicates for tableA => none
+         *  4. Create tableB
+         *     Fetch predicates for tableB => Only match is b.value = 1
+         * </pre>
          */
-        boolean allowNullPredicates = true;
+        Set<TableSourceReference> constrainedTableSources = new HashSet<>();
 
         /**
          * List with pair of analyzed predicates (from WHERE or JOIN etc.) along with a set of allowed push down table sources
@@ -88,13 +111,13 @@ class PredicatePushDown extends ALogicalPlanOptimizer<PredicatePushDown.Ctx>
         }
 
         /** Add analyze result returning the index of the result for later use */
-        int add(AnalyzeResult analyzeResult, Set<TableSourceReference> allowedTableSources)
+        int add(AnalyzeResult analyzeResult, Set<TableSourceReference> constrainedTableSources)
         {
             if (analyzeResults == null)
             {
                 analyzeResults = new ArrayList<>();
             }
-            analyzeResults.add(Pair.of(allowedTableSources, analyzeResult));
+            analyzeResults.add(Pair.of(constrainedTableSources, analyzeResult));
             return analyzeResults.size() - 1;
         }
 
@@ -113,22 +136,35 @@ class PredicatePushDown extends ALogicalPlanOptimizer<PredicatePushDown.Ctx>
                 return null;
             }
 
+            // If we have a constraint on input table source
+            // we can only extract those anaylyze results that has that table source constrained
+            // else we can only extract those results with no constraints
+            boolean checkConstrainedTableSources = constrainedTableSources.contains(tableSource);
+
             // Extract pairs from all analyze result and combine a predicate
             List<AnalyzePair> pairs = new ArrayList<>();
             int size = analyzeResults.size();
             for (int i = 0; i < size; i++)
             {
                 Pair<Set<TableSourceReference>, AnalyzeResult> p = analyzeResults.get(i);
-                if (!p.getKey()
-                        .isEmpty()
+
+                // Analyze result is constrained to table sources that is not among input table source => move on
+                if (checkConstrainedTableSources
                         && !p.getKey()
                                 .contains(tableSource))
                 {
                     continue;
                 }
+                // or we don't have any constraints on input table source but the analyze result has => move on
+                else if (!checkConstrainedTableSources
+                        && !p.getKey()
+                                .isEmpty())
+                {
+                    continue;
+                }
 
                 Pair<List<AnalyzePair>, AnalyzeResult> pair = p.getValue()
-                        .extractPushdownPairs(tableSource, allowNullPredicates);
+                        .extractPushdownPairs(tableSource);
                 if (pair != null)
                 {
                     // Collect the pairs
@@ -201,33 +237,25 @@ class PredicatePushDown extends ALogicalPlanOptimizer<PredicatePushDown.Ctx>
     {
         boolean isLeft = plan.getType() == Type.LEFT;
 
-        Set<TableSourceReference> allowedTableSources = emptySet();
+        Set<TableSourceReference> constrainedTableSoueces = emptySet();
 
-        // Collect allowed table sources from the inner plan
-        // Ie. we can only push down predicates belonging to the inner table sources
-        // when having a left join
+        // We don't push anything down to a LEFT join
+        // That is up to the user to optimize at the moment.
         if (isLeft)
         {
-            allowedTableSources = new HashSet<>();
+            constrainedTableSoueces = new HashSet<>();
             plan.getInner()
-                    .accept(TableSourceVisitor.INSTANCE, allowedTableSources);
+                    .accept(TableSourceVisitor.INSTANCE, constrainedTableSoueces);
         }
+
+        Set<TableSourceReference> prevConstrainedTableSources = new HashSet<>(context.constrainedTableSources);
+
+        context.constrainedTableSources.addAll(constrainedTableSoueces);
 
         // Add to result then visit down stream plans
         // CSOFF
-        int resultIndex = context.add(PredicateAnalyzer.analyze(plan.getCondition()), allowedTableSources);
-        boolean prevAllowNullPredicates = context.allowNullPredicates;
+        int resultIndex = context.add(PredicateAnalyzer.analyze(plan.getCondition()), constrainedTableSoueces);
         // CSON
-
-        // @formatter:off
-        // Push down rules regarding null
-        //
-        //              left        inner       cross       outer
-        // IS NULL      X           PUSH DOWN   PUSH DOWN   X
-        // IS NOT NULL  PUSH DOWN   PUSH DOWN   PUSH DOWN   PUSH DOWN
-        // @formatter:on
-
-        context.allowNullPredicates = !isLeft;
 
         ILogicalPlan outer = plan.getOuter()
                 .accept(this, context);
@@ -235,7 +263,7 @@ class PredicatePushDown extends ALogicalPlanOptimizer<PredicatePushDown.Ctx>
                 .accept(this, context);
 
         // Restore previous values
-        context.allowNullPredicates = prevAllowNullPredicates;
+        context.constrainedTableSources = prevConstrainedTableSources;
 
         // Extract remaining predicate pairs and use when re-creating join
         AnalyzeResult analyzeResult = context.analyzeResults.remove(resultIndex)

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/SchemaResolver.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/SchemaResolver.java
@@ -139,7 +139,7 @@ public class SchemaResolver extends ALogicalPlanOptimizer<SchemaResolver.Ctx>
         else
         {
             TableSchema tableSchema = catalog.getTableSchema(context.getSession(), catalogAlias, plan.getTableSource()
-                    .getName());
+                    .getName(), plan.getOptions());
 
             schema = tableSchema.getSchema();
             if (schema.getSize() > 0

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/physicalplan/DatasourceOptions.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/physicalplan/DatasourceOptions.java
@@ -1,5 +1,6 @@
 package se.kuseman.payloadbuilder.core.physicalplan;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -19,7 +20,7 @@ public class DatasourceOptions implements IDatasourceOptions
 
     public DatasourceOptions(List<Option> options)
     {
-        this.options = requireNonNull(options, "options");
+        this.options = unmodifiableList(requireNonNull(options, "options"));
     }
 
     @Override
@@ -51,4 +52,9 @@ public class DatasourceOptions implements IDatasourceOptions
         return null;
     }
 
+    @Override
+    public List<Option> getOptions()
+    {
+        return options;
+    }
 }

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/StatementPlanner.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/StatementPlanner.java
@@ -77,6 +77,17 @@ public class StatementPlanner
     {
         ExecutionContext context = new ExecutionContext(session);
         Context ctx = new Context(context);
+
+        // Add existing session tables into context
+        // This is used when working in a state full session system like Queryeer
+        // where the session is reused across executions.
+        session.getTemporaryTables()
+                .forEach(e -> ctx.schemaByTempTable.put(e.getKey(), new TableSchema(e.getValue()
+                        .getTupleVector()
+                        .getSchema(),
+                        e.getValue()
+                                .getIndices())));
+
         return new QueryStatement(query.getStatements()
                 .stream()
                 .map(s -> s.accept(STATEMENT_REWRITER, ctx))

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ALogicalPlanOptimizerTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ALogicalPlanOptimizerTest.java
@@ -2,10 +2,13 @@ package se.kuseman.payloadbuilder.core.logicalplan.optimization;
 
 import static se.kuseman.payloadbuilder.api.QualifiedName.of;
 
+import java.util.List;
+
 import se.kuseman.payloadbuilder.api.QualifiedName;
 import se.kuseman.payloadbuilder.api.catalog.Catalog;
 import se.kuseman.payloadbuilder.api.catalog.Column;
 import se.kuseman.payloadbuilder.api.catalog.Column.Type;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableSchema;
@@ -69,7 +72,7 @@ public abstract class ALogicalPlanOptimizerTest extends ALogicalPlanTest
     private final Catalog asteriskCatalog = new Catalog(TEST)
     {
         @Override
-        public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+        public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
         {
             String t = table.toString()
                     .toLowerCase();

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/QueryPlannerTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/QueryPlannerTest.java
@@ -37,6 +37,7 @@ import se.kuseman.payloadbuilder.api.catalog.ISortItem.NullOrder;
 import se.kuseman.payloadbuilder.api.catalog.ISortItem.Order;
 import se.kuseman.payloadbuilder.api.catalog.Index;
 import se.kuseman.payloadbuilder.api.catalog.Index.ColumnsType;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
 import se.kuseman.payloadbuilder.api.catalog.ScalarFunctionInfo;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
@@ -264,14 +265,14 @@ public class QueryPlannerTest extends APhysicalPlanTest
         TestCatalog t = new TestCatalog(emptyMap())
         {
             @Override
-            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
             {
                 if (table.toString()
                         .equalsIgnoreCase("tableB"))
                 {
                     return new TableSchema(Schema.EMPTY, asList(new Index(table, asList("col"), ColumnsType.ANY_IN_ORDER)));
                 }
-                return super.getTableSchema(session, catalogAlias, table);
+                return super.getTableSchema(session, catalogAlias, table, options);
             }
         };
         catalogRegistry.registerCatalog("t", t);
@@ -853,14 +854,14 @@ public class QueryPlannerTest extends APhysicalPlanTest
         TestCatalog t = new TestCatalog(emptyMap())
         {
             @Override
-            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
             {
                 if (table.toString()
                         .equalsIgnoreCase("tableB"))
                 {
                     return new TableSchema(Schema.EMPTY, asList(new Index(table, asList("col"), ColumnsType.ANY_IN_ORDER)));
                 }
-                return super.getTableSchema(session, catalogAlias, table);
+                return super.getTableSchema(session, catalogAlias, table, options);
             }
         };
         catalogRegistry.registerCatalog("t", t);
@@ -930,7 +931,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         TestCatalog t = new TestCatalog(emptyMap())
         {
             @Override
-            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
             {
                 String tbl = table.toString();
                 if (tbl.equalsIgnoreCase("tableB"))
@@ -941,7 +942,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 {
                     return new TableSchema(Schema.EMPTY, asList(new Index(table, asList("col"), ColumnsType.ANY_IN_ORDER)));
                 }
-                return super.getTableSchema(session, catalogAlias, table);
+                return super.getTableSchema(session, catalogAlias, table, options);
             }
         };
         catalogRegistry.registerCatalog("t", t);
@@ -1028,14 +1029,14 @@ public class QueryPlannerTest extends APhysicalPlanTest
         TestCatalog t = new TestCatalog(emptyMap())
         {
             @Override
-            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+            public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
             {
                 if (table.toString()
                         .equalsIgnoreCase("tableB"))
                 {
                     return new TableSchema(Schema.EMPTY, asList(new Index(table, asList("col", "col2"), ColumnsType.ANY_IN_ORDER)));
                 }
-                return super.getTableSchema(session, catalogAlias, table);
+                return super.getTableSchema(session, catalogAlias, table, options);
             }
         };
         catalogRegistry.registerCatalog("t", t);

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/test/TestHarnessRunner.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/test/TestHarnessRunner.java
@@ -36,6 +36,7 @@ import se.kuseman.payloadbuilder.api.catalog.DatasourceData;
 import se.kuseman.payloadbuilder.api.catalog.FunctionInfo.FunctionType;
 import se.kuseman.payloadbuilder.api.catalog.IDatasource;
 import se.kuseman.payloadbuilder.api.catalog.IDatasourceOptions;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
 import se.kuseman.payloadbuilder.api.catalog.ScalarFunctionInfo;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
@@ -373,7 +374,7 @@ public class TestHarnessRunner
         }
 
         @Override
-        public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table)
+        public TableSchema getTableSchema(IQuerySession session, String catalogAlias, QualifiedName table, List<Option> options)
         {
             if (schemaLess)
             {

--- a/payloadbuilder-core/src/test/resources/harnessCases/BaseContructs.json
+++ b/payloadbuilder-core/src/test/resources/harnessCases/BaseContructs.json
@@ -281,6 +281,17 @@
       "expectedMessageContains": "d.id cannot be bound"
     },
     {
+      "name": "Like ",
+      "query": [
+        "select 'hello' like '%ell%' _like, 'hello' not like '%ell%' _notLike "
+      ],
+      "expectedResultSets": [
+        [
+          [{ "key": "_like", "value": true }, { "key": "_notLike", "value": false }]
+        ]
+      ]
+    },
+    {
       "name": "Distinct",
       "query": [
         "select distinct d.row_id, length(data) len from data d"

--- a/payloadbuilder-core/src/test/resources/harnessCases/Joins.json
+++ b/payloadbuilder-core/src/test/resources/harnessCases/Joins.json
@@ -573,24 +573,48 @@
     {
       "name": "Join with sub query with sub query expression (object)",
       "query": [
-      	"select x.* ",
-		"from range(1, 3) v ",
-		"inner join ",
-		"( ",
-		"    select ",
-		"    Value ",
-		"    , ( ",
-		"        select Value key ",
-		"        for object ",
-		"      ) map ",
-		"    from range(1, 3) ",
-		") x ",
-		"  on  x.Value = v.Value "
+        "select x.* ",
+        "from range(1, 3) v ",
+        "inner join ",
+        "( ",
+        "    select ",
+        "    Value ",
+        "    , ( ",
+        "        select Value key ",
+        "        for object ",
+        "      ) map ",
+        "    from range(1, 3) ",
+        ") x ",
+        "  on  x.Value = v.Value "
       ],
       "expectedResultSets": [
         [
           [{ "key": "Value", "value": 1 },{ "key": "map", "value": { "key": 1 } }],
           [{ "key": "Value", "value": 2 },{ "key": "map", "value": { "key": 2 } }]
+        ]
+      ]
+    },
+    {
+      "name": "Left joins with where predicates",
+      "query": [
+        "select x.Value valueX, y.Value valueY ",
+        "from range(1, 3) x ",
+        "left join range(2, 4) y ",
+        "  on y.Value = x.Value ",
+        "where y.Value is null ",
+        "",
+        "select x.Value valueX, y.Value valueY ",
+        "from range(1, 3) x ",
+        "left join range(2, 4) y ",
+        "  on y.Value = x.Value ",
+        "where y.Value is not null "
+      ],
+      "expectedResultSets": [
+        [
+          [{ "key": "valueX", "value": 1 }, { "key": "valueY", "value": null }]
+        ],
+        [
+          [{ "key": "valueX", "value": 2 }, { "key": "valueY", "value": 2 }]
         ]
       ]
     }


### PR DESCRIPTION
…rn those into table sources

This catalog supports indexed access via table hints which specifies query patterns with placeholder fields that acts as predicated columns
fix: Don't push where predicates down to left joined table sources