### PR TITLE
feat: Add query option to force no index on a join that otherwise wou…

### DIFF
--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/JdbcCatalog.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/JdbcCatalog.java
@@ -149,7 +149,7 @@ public class JdbcCatalog extends Catalog
     {
         List<IPredicate> predicates = getPredicates(data);
         List<ISortItem> sortItems = getSortItems(data);
-        return new JdbcDatasource(this, catalogAlias, table, seekPredicate, data.getProjection(), predicates, sortItems);
+        return new JdbcDatasource(this, catalogAlias, table, seekPredicate, data.getProjection(), predicates, sortItems, data.getOptions());
     }
 
     private List<IPredicate> getPredicates(DatasourceData data)

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/dialect/OracleDialect.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/dialect/OracleDialect.java
@@ -28,7 +28,7 @@ class OracleDialect implements SqlDialect
         {
             if (i > 0)
             {
-                sb.append(" UNION ");
+                sb.append(" UNION ALL ");
             }
 
             sb.append("SELECT ");

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/dialect/SqlDialect.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/dialect/SqlDialect.java
@@ -43,7 +43,7 @@ public interface SqlDialect
         {
             if (i > 0)
             {
-                sb.append(" UNION ");
+                sb.append(" UNION ALL ");
             }
 
             sb.append("SELECT ");


### PR DESCRIPTION
…ld be an indexseek. This is needed

sometimes where a simple hashmatch is actually faster (usually when there is many rows with no hits then all batching will eat up all the performance)
feat(JbcCatalog): Add two table options:
 - tableHints: Adds a hints string after the table alias part. Example for SQL server is to add "WITH(NOLOCK)"
 - projection: A little shortcut until projection pushdown is implemented in PLB core. Now one can hint a comma separated string that will be the projection to the downstream select, this to avoid excessive data to be fetched due to asterisk select. fix: Change to UNION ALL when building index seek query, the input values are unique