### PR TITLE
fix: Remove TableSourceReference.Type#CONSTANTSCAN since that was a w…

### DIFF
--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/CoreColumn.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/CoreColumn.java
@@ -58,15 +58,9 @@ public class CoreColumn extends Column
     }
 
     /** Copy ctor. New type of column */
-    public CoreColumn(CoreColumn source, ResolvedType type)
+    public CoreColumn(CoreColumn source, ResolvedType type, TableSourceReference tableSource)
     {
-        this(source.getName(), type, source.outputName, source.internal, source.tableSourceReference, source.columnType);
-    }
-
-    /** Copy ctor. New tablesource of column */
-    public CoreColumn(CoreColumn source, TableSourceReference tableSource)
-    {
-        this(source.getName(), source.getType(), source.outputName, source.internal, tableSource, source.columnType);
+        this(source.getName(), type, source.outputName, source.internal, tableSource, source.columnType);
     }
 
     public CoreColumn(String name, ResolvedType type, String outputName, boolean internal, TableSourceReference tableSourceReference, Type columnType)

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/TableSourceReference.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/TableSourceReference.java
@@ -99,7 +99,6 @@ public class TableSourceReference
         TABLE,
         FUNCTION,
         EXPRESSION,
-        SUBQUERY,
-        CONSTANTSCAN
+        SUBQUERY
     }
 }

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/ObjectArrayFunctionImpl.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/ObjectArrayFunctionImpl.java
@@ -19,7 +19,7 @@ class ObjectArrayFunctionImpl
     static ResolvedType getAggregateType(List<IExpression> arguments)
     {
         // This is the aggregate but the arguments are considered non aggregate for the schema
-        Schema schema = SchemaUtils.getSchema(arguments, false);
+        Schema schema = SchemaUtils.getSchema(null, arguments, false);
         return ResolvedType.table(schema);
     }
 

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/ColumnExpression.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/ColumnExpression.java
@@ -194,9 +194,6 @@ public class ColumnExpression implements IColumnExpression, HasAlias, HasColumnR
             // This happens when having an asterisk schema and we only know which table source
             // this columns belongs to and we don't have an ordinal
             if (columnReference != null
-                    // Sub query table sources are only a marker during planning and should not be compared
-                    && columnReference.tableSourceReference()
-                            .getType() != TableSourceReference.Type.SUBQUERY
                     && (columnTableSourceReference == null
                             || columnReference.tableSourceReference()
                                     .getId() != columnTableSourceReference.getId()))

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/ICoreExpressionVisitor.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/ICoreExpressionVisitor.java
@@ -8,17 +8,17 @@ public interface ICoreExpressionVisitor<T, C> extends IExpressionVisitor<T, C>
     default T visit(AsteriskExpression expression, C context)
     {
         return visitChildren(context, expression);
-    };
+    }
 
     default T visit(UnresolvedColumnExpression expression, C context)
     {
         return visitChildren(context, expression);
-    };
+    }
 
     default T visit(UnresolvedFunctionCallExpression expression, C context)
     {
         return visitChildren(context, expression);
-    };
+    }
 
     default T visit(UnresolvedSubQueryExpression expression, C context)
     {
@@ -44,5 +44,4 @@ public interface ICoreExpressionVisitor<T, C> extends IExpressionVisitor<T, C>
     {
         return visitChildren(context, expression);
     }
-
 }

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/Projection.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/Projection.java
@@ -5,9 +5,11 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 import java.util.List;
+import java.util.Objects;
 
 import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.expression.IExpression;
+import se.kuseman.payloadbuilder.core.catalog.TableSourceReference;
 import se.kuseman.payloadbuilder.core.common.SchemaUtils;
 
 /** Projects input with a list of expressions */
@@ -17,11 +19,13 @@ public class Projection implements ILogicalPlan
     private final ILogicalPlan input;
     /** Projection expressions */
     private final List<IExpression> expressions;
+    private final TableSourceReference parentTableSource;
 
-    public Projection(ILogicalPlan input, List<IExpression> expressions)
+    public Projection(ILogicalPlan input, List<IExpression> expressions, TableSourceReference parentTableSource)
     {
         this.input = requireNonNull(input, "input");
         this.expressions = requireNonNull(expressions, "expressions");
+        this.parentTableSource = parentTableSource;
     }
 
     public List<IExpression> getExpressions()
@@ -34,10 +38,15 @@ public class Projection implements ILogicalPlan
         return input;
     }
 
+    public TableSourceReference getParentTableSource()
+    {
+        return parentTableSource;
+    }
+
     @Override
     public Schema getSchema()
     {
-        return SchemaUtils.getSchema(expressions, false);
+        return SchemaUtils.getSchema(parentTableSource, expressions, false);
     }
 
     @Override
@@ -72,7 +81,8 @@ public class Projection implements ILogicalPlan
         else if (obj instanceof Projection that)
         {
             return input.equals(that.input)
-                    && expressions.equals(that.expressions);
+                    && expressions.equals(that.expressions)
+                    && Objects.equals(parentTableSource, that.parentTableSource);
         }
         return false;
     }

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ALogicalPlanOptimizer.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ALogicalPlanOptimizer.java
@@ -379,7 +379,7 @@ abstract class ALogicalPlanOptimizer<C extends ALogicalPlanOptimizer.Context> ex
             expressions = visit(plan, plan.getExpressions(), context);
         }
         return new Projection(plan.getInput()
-                .accept(this, context), expressions);
+                .accept(this, context), expressions, plan.getParentTableSource());
     }
 
     protected ILogicalPlan create(Aggregate plan, C context)
@@ -406,7 +406,7 @@ abstract class ALogicalPlanOptimizer<C extends ALogicalPlanOptimizer.Context> ex
         }
 
         return new Aggregate(plan.getInput()
-                .accept(this, context), aggregateExpressions, projectionExpressions);
+                .accept(this, context), aggregateExpressions, projectionExpressions, plan.getParentTableSource());
     }
 
     protected ILogicalPlan create(Join plan, C context)
@@ -608,17 +608,6 @@ abstract class ALogicalPlanOptimizer<C extends ALogicalPlanOptimizer.Context> ex
         public Void visit(SubQuery plan, Set<TableSourceReference> context)
         {
             context.add(plan.getTableSource());
-            return super.visit(plan, context);
-        }
-
-        @Override
-        public Void visit(ConstantScan plan, Set<TableSourceReference> context)
-        {
-            TableSourceReference tableSource = plan.getTableSource();
-            if (tableSource != null)
-            {
-                context.add(tableSource);
-            }
             return super.visit(plan, context);
         }
     }

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ColumnOrdinalResolver.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ColumnOrdinalResolver.java
@@ -79,7 +79,7 @@ class ColumnOrdinalResolver extends ALogicalPlanOptimizer<ColumnOrdinalResolver.
         context.schema = prevSchema;
         context.outerSchema = prevOuterSchema;
 
-        return new Projection(input, expressions);
+        return new Projection(input, expressions, plan.getParentTableSource());
     }
 
     @Override
@@ -161,7 +161,7 @@ class ColumnOrdinalResolver extends ALogicalPlanOptimizer<ColumnOrdinalResolver.
                 .stream()
                 .map(e -> (IAggregateExpression) ColumnOrdinalRewriter.INSTANCE.visit(e, context))
                 .collect(toList());
-        return new Aggregate(input, aggregateExpressions, projectionExpressions);
+        return new Aggregate(input, aggregateExpressions, projectionExpressions, plan.getParentTableSource());
     }
 
     @Override

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ComputedExpressionPushDown.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ComputedExpressionPushDown.java
@@ -182,7 +182,7 @@ class ComputedExpressionPushDown extends ALogicalPlanOptimizer<ComputedExpressio
         if (planData.sortItems.isEmpty())
         {
             return new Projection(plan.getInput()
-                    .accept(this, context), projectionExpressions);
+                    .accept(this, context), projectionExpressions, plan.getParentTableSource());
         }
 
         List<IExpression> newProjectionExpressions = new ArrayList<>(projectionExpressions);
@@ -337,7 +337,7 @@ class ComputedExpressionPushDown extends ALogicalPlanOptimizer<ComputedExpressio
         ILogicalPlan input = plan.getInput()
                 .accept(this, context);
 
-        return new Projection(input, newProjectionExpressions);
+        return new Projection(input, newProjectionExpressions, plan.getParentTableSource());
     }
 
     @Override
@@ -446,10 +446,10 @@ class ComputedExpressionPushDown extends ALogicalPlanOptimizer<ComputedExpressio
                     .collect(toList());
             // We need all the input besides the compute projections
             projections.add(new AsteriskExpression(null));
-            planInput = new Projection(planInput, projections);
+            planInput = new Projection(planInput, projections, null);
         }
 
-        return new Aggregate(planInput, plan.getAggregateExpressions(), planProjections);
+        return new Aggregate(planInput, plan.getAggregateExpressions(), planProjections, plan.getParentTableSource());
     }
 
     private boolean shouldReplaceSortItem(IExpression sortItemExpression, IExpression projectionExpression)

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/SchemaResolver.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/SchemaResolver.java
@@ -108,7 +108,7 @@ public class SchemaResolver extends ALogicalPlanOptimizer<SchemaResolver.Ctx>
                 .collect(toList());
 
         context.resolvingAggregateProjectionExpression = false;
-        return new Aggregate(input, aggregateExpressions, projectionExpressions);
+        return new Aggregate(input, aggregateExpressions, projectionExpressions, plan.getParentTableSource());
     }
 
     @Override

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/QueryPlanner.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/QueryPlanner.java
@@ -105,7 +105,7 @@ class QueryPlanner implements ILogicalPlanVisitor<IPhysicalPlan, StatementPlanne
             input = p.getInput();
         }
 
-        return wrapWithAnalyze(context, new se.kuseman.payloadbuilder.core.physicalplan.Projection(context.getNextNodeId(), input, expressions));
+        return wrapWithAnalyze(context, new se.kuseman.payloadbuilder.core.physicalplan.Projection(context.getNextNodeId(), input, expressions, plan.getParentTableSource()));
     }
 
     @Override
@@ -201,7 +201,7 @@ class QueryPlanner implements ILogicalPlanVisitor<IPhysicalPlan, StatementPlanne
         IPhysicalPlan input = plan.getInput()
                 .accept(this, context);
 
-        return wrapWithAnalyze(context, new HashAggregate(context.getNextNodeId(), input, plan.getAggregateExpressions(), plan.getProjectionExpressions()));
+        return wrapWithAnalyze(context, new HashAggregate(context.getNextNodeId(), input, plan.getAggregateExpressions(), plan.getProjectionExpressions(), plan.getParentTableSource()));
     }
 
     @Override

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/StatementRewriter.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/StatementRewriter.java
@@ -160,7 +160,8 @@ class StatementRewriter implements StatementVisitor<Statement, StatementPlanner.
                                     new Projection(ConstantScan.ONE_ROW_EMPTY_SCHEMA,
                                             asList(new LiteralStringExpression("System functions"),
                                                    new LiteralStringExpression(UTF8String.EMPTY),
-                                                   new LiteralStringExpression(UTF8String.EMPTY))),
+                                                   new LiteralStringExpression(UTF8String.EMPTY)),
+                                            null),
                                     new Sort(systemFunctionsScan, sortItems)), null), false).accept(this, context);
                     //@formatter:on
 

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/ALogicalPlanTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/ALogicalPlanTest.java
@@ -33,7 +33,12 @@ public abstract class ALogicalPlanTest extends AExpressionTest
 
     protected Projection projection(ILogicalPlan input, List<IExpression> expressions)
     {
-        return new Projection(input, expressions);
+        return new Projection(input, expressions, null);
+    }
+
+    protected Projection projection(ILogicalPlan input, List<IExpression> expressions, TableSourceReference parentTableSource)
+    {
+        return new Projection(input, expressions, parentTableSource);
     }
 
     protected SortItem sortItem(IExpression expression, Order order)

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ComputedExpressionPushDownTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ComputedExpressionPushDownTest.java
@@ -79,7 +79,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                             emptySet(),
                             false,
                             Schema.EMPTY),
-                        List.of(e("b.col1"), new AliasExpression(e("t.col1"), "col1", true))),
+                        List.of(e("b.col1"), new AliasExpression(e("t.col1"), "col1", true)),
+                        null),
                 List.of(sortItem(e("t.col1"), Order.ASC))
                 );
         //CSON
@@ -116,7 +117,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                     new Projection(
                         tableScan(Schema.of(ast("t", table)), table),
                         List.of(new AliasExpression(new SubscriptExpression(new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("concat"), null,
-                                asList(uce("col"), intLit(1))), intLit(0)), "__expr0", "concat(col, 1)[0]", false))),
+                                asList(uce("col"), intLit(1))), intLit(0)), "__expr0", "concat(col, 1)[0]", false)),
+                        null),
                 List.of(sortItem(uce("__expr0"), Order.ASC))
                 );
         //CSON
@@ -157,7 +159,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                             new AggregateWrapperExpression(e("col1"), false, false),
                             new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))),
                             new AggregateWrapperExpression(e("col3"), false, true)
-                        )),
+                        ),
+                        null),
                 asList(sortItem(add(e("col1"), e("col3")), Order.ASC))
                 );
         //@formatter:on
@@ -194,7 +197,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                             new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))),
                             new AggregateWrapperExpression(new AliasExpression(
                                     new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("min"), null, asList(uce("__expr0"))), "__expr1"), false, true)
-                        )),
+                        ),
+                        null),
                 asList(sortItem(uce("__expr1"), Order.ASC))
                 );
         
@@ -247,7 +251,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                         new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))),
                                         new AggregateWrapperExpression(new AliasExpression(
                                                 new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("min"), null, asList(uce("__expr0"))), "__expr1"), false, true)
-                                    )),
+                                    ),
+                                    null),
                             asList(sortItem(uce("__expr1"), Order.ASC))),
                             null), "x")), null);
         //@formatter:on
@@ -314,14 +319,16 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                                         new Projection(
                                                             tableScan(resolvedSchemaSTableB, sTableB),
                                                             asList(uce("b", "col1"),
-                                                            new AliasExpression(uce("b", "col2"), "col2", true))),            // Internal column added for sorting
+                                                            new AliasExpression(uce("b", "col2"), "col2", true)),            // Internal column added for sorting
+                                                            null),
                                                         asList(sortItem(uce("b", "col2"), Order.ASC))),
                                                     "",
                                                     "object",
                                                     null),
                                                 null),
                                                 "obj1"),
-                                                new AliasExpression(uce("a", "col2"), "col2", true))),                       // Internal column added for sorting
+                                                new AliasExpression(uce("a", "col2"), "col2", true)),                       // Internal column added for sorting
+                                            null),
                                         asList(sortItem(uce("a", "col2"), Order.ASC))),
                                     "",
                                     "object_array",
@@ -370,7 +377,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                             new AggregateWrapperExpression(new AliasExpression(
                                     new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("min"), null,
                                             asList(add(e("COL1"), e("col2")))), "__expr0", "min(COL1 + col2)", false), false, false)
-                        )),
+                        ),
+                        null),
                 asList(sortItem(uce("__expr0"), Order.ASC))
                 );
         
@@ -421,7 +429,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                             new AggregateWrapperExpression(new AliasExpression(
                                     new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("min"), null,
                                             asList(add(e("col1"), e("col2")))), "compute", false), false, false)
-                        )),
+                        ),
+                        null),
                 asList(sortItem(e("compute"), Order.ASC))
                 );
         
@@ -462,7 +471,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                             new AggregateWrapperExpression(e("col1"), false, false),
                             new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))),
                             new AggregateWrapperExpression(e("col2"), false, true)
-                        )),
+                        ),
+                        null),
                 asList(sortItem(e("col1 + col2"), Order.ASC))
                 );
 
@@ -594,7 +604,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
         ILogicalPlan plan = getSchemaResolvedPlan(query);
         ILogicalPlan actual = optimize(context, plan);
 
-        TableSourceReference subQueryX = new TableSourceReference(1, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("x"), "x");
+        TableSourceReference table = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", of("table"), "t");
+        TableSourceReference subQueryX = new TableSourceReference(0, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("x"), "x");
 
         // Will be any push downs here since we have an asterisk and will have to resolve ordinal runtime
         //@formatter:off
@@ -694,7 +705,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
         ILogicalPlan plan = getSchemaResolvedPlan(query);
         ILogicalPlan actual = optimize(context, plan);
 
-        TableSourceReference subQueryX = new TableSourceReference(1, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("x"), "x");
+        TableSourceReference table = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", of("table"), "t");
+        TableSourceReference subQueryX = new TableSourceReference(0, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("x"), "x");
 
         // Expression on ordinal 1 will be used
         //@formatter:off
@@ -1218,7 +1230,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                     asList(e("t.col")),
                     asList(new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))),
                            new AggregateWrapperExpression(add(e("t.col"),  new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col1")))), false, false)
-                           ));
+                           ),
+                    null);
         
         assertEquals(Schema.of(
                 new CoreColumn("", ResolvedType.of(Type.Int), "count(1)", false, CoreColumn.Type.REGULAR),
@@ -1254,8 +1267,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                     asList(new AggregateWrapperExpression(
                                 new AliasExpression(
                                     new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "cnt"), false, false),
-                           new AggregateWrapperExpression(e("col"), false, false)
-                            ));
+                           new AggregateWrapperExpression(e("col"), false, false)),
+                    null);
         //@formatter:on
 
         // System.out.println(expected.print(0));
@@ -1287,7 +1300,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                new AggregateWrapperExpression(
                                        new AliasExpression(
                                            new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))), "__expr0"), false, true)
-                                )),
+                                ),
+                        null),
                     null,
                     e("__expr0 > 10"));
         
@@ -1331,7 +1345,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                new AggregateWrapperExpression(
                                        new AliasExpression(
                                            new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))), "__expr0"), false, true)
-                                )),
+                                ),
+                        null),
                     null,
                     e("__expr0 > 10"));
         
@@ -1378,7 +1393,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                    new AggregateWrapperExpression(
                                            new AliasExpression(
                                                new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))), "__expr2"), false, true)
-                                    )),
+                                    ),
+                            null),
                         null,
                         e("__expr2 < 10 and (2 + __expr1) > 20")),
                     asList(sortItem(e("__expr1"), Order.ASC)));
@@ -1431,7 +1447,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                    new AggregateWrapperExpression(
                                            new AliasExpression(
                                                new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("max"), null, asList(e("col2"))), "__expr1"), false, true)
-                                    )),
+                                    ),
+                            null),
                         null,
                         e("__expr1 < 10 and (2 + __expr0) > 20")),
                     asList(sortItem(e("__expr0"), Order.ASC)));
@@ -1473,7 +1490,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                new AggregateWrapperExpression(
                                        new AliasExpression(
                                            new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "__expr0", "count(1)", false), false, false)
-                                )),
+                                ),
+                        null),
                     null,
                     e("__expr0 > 10"));
         
@@ -1514,7 +1532,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                    new AggregateWrapperExpression(
                                            new AliasExpression(
                                                new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "__expr0", "count(1)", false), false, false)
-                                    )),
+                                    ),
+                            null),
                         null,
                         e("__expr0 > 10")),
                     asList(sortItem(e("__expr0"), Order.DESC)));
@@ -1555,7 +1574,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                    new AggregateWrapperExpression(
                                            new AliasExpression(
                                                new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "numberOfRecords", false), false, false)
-                                    )),
+                                    ),
+                            null),
                         null,
                         e("numberOfRecords > 10")),
                     asList(sortItem(e("numberOfRecords"), Order.DESC)));
@@ -1594,7 +1614,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                     new AliasExpression(
                                         new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "cnt"), false, false),
                                new AggregateWrapperExpression(e("col"), false, false)
-                                )),
+                                ),
+                        null),
                     asList(sortItem(e("cnt"), Order.ASC)));
 
         Assertions.assertThat(actual.getSchema())
@@ -1633,7 +1654,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                         asList(new AggregateWrapperExpression(
                                     new AliasExpression(
                                         new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "cnt"), false, false),
-                               new AggregateWrapperExpression(e("col"), false, true))),
+                               new AggregateWrapperExpression(e("col"), false, true)),
+                        null),
                     asList(sortItem(e("col"), Order.ASC)));
         //@formatter:on
 
@@ -1669,7 +1691,8 @@ public class ComputedExpressionPushDownTest extends ALogicalPlanOptimizerTest
                                     new AliasExpression(
                                         new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))), "cnt"), false, false),
                                new AggregateWrapperExpression(e("col"), false, true),
-                               new AggregateWrapperExpression(e("col2"), false, true))),
+                               new AggregateWrapperExpression(e("col2"), false, true)),
+                        null),
                     asList(sortItem(add(add(e("col"), intLit(10)), e("col2")), Order.ASC)));
         //@formatter:on
 

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ProjectionPushDownTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ProjectionPushDownTest.java
@@ -67,7 +67,8 @@ public class ProjectionPushDownTest extends ALogicalPlanOptimizerTest
                     subQuery(
                         projection(
                             tableScan(schema, table, asList("col1", "col2")),
-                            asList(cre("col1", table), cre("col2", table))),
+                            asList(cre("col1", table), cre("col2", table)),
+                            subQueryX),
                     subQueryX),
                     asList(cre("col1", table, 0))
                     );

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/parser/QueryParserTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/parser/QueryParserTest.java
@@ -298,11 +298,13 @@ public class QueryParserTest extends Assert
                                             asList(e("a")),
                                             emptyList(),
                                             null),
-                                        asList(new AsteriskExpression(QualifiedName.of("a"), null))),
+                                        asList(new AsteriskExpression(QualifiedName.of("a"), null)),
+                                        null),
                                     "",
                                     "objectarray",
                                     null),
-                                null))),
+                                null)),
+                        null),
                     false);
         //@formatter:on
         Statement actual = s("select a.col, (select a.* from open_table(a) a for objectarray) from \"table\" a where a.col > 10");

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/ConstantScanTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/ConstantScanTest.java
@@ -19,7 +19,7 @@ public class ConstantScanTest extends APhysicalPlanTest
     @Test
     public void test()
     {
-        IPhysicalPlan plan = new Projection(1, new ConstantScan(0, TupleVector.CONSTANT), asList(new AliasExpression(e("10"), "TEN"), new AliasExpression(e("'hello'"), "HELLO")));
+        IPhysicalPlan plan = new Projection(1, new ConstantScan(0, TupleVector.CONSTANT), asList(new AliasExpression(e("10"), "TEN"), new AliasExpression(e("'hello'"), "HELLO")), null);
         Schema expectedSchema = Schema.of(col("TEN", ResolvedType.of(Type.Int), null), col("HELLO", ResolvedType.of(Type.String), null));
 
         assertEquals(expectedSchema, plan.getSchema());

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/HashAggregateTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/HashAggregateTest.java
@@ -43,7 +43,7 @@ public class HashAggregateTest extends APhysicalPlanTest
         {
         });
 
-        new HashAggregate(0, scan(ds, table, schema), asList(ce("col1")), emptyList());
+        new HashAggregate(0, scan(ds, table, schema), asList(ce("col1")), emptyList(), null);
     }
 
     @Test(
@@ -55,7 +55,7 @@ public class HashAggregateTest extends APhysicalPlanTest
         {
         });
 
-        new HashAggregate(0, scan(ds, table, schema), emptyList(), asList(new AggregateWrapperExpression(ce("col1"), false, false)));
+        new HashAggregate(0, scan(ds, table, schema), emptyList(), asList(new AggregateWrapperExpression(ce("col1"), false, false)), null);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class HashAggregateTest extends APhysicalPlanTest
         //@formatter:off
         IPhysicalPlan plan =
                 new Sort(2,
-                        new HashAggregate(1, scan(ds, table, Schema.EMPTY), emptyList(), emptyList()),
+                        new HashAggregate(1, scan(ds, table, Schema.EMPTY), emptyList(), emptyList(), null),
                 asList(sortItem(ce("col1", 0), Order.ASC, NullOrder.UNDEFINED)));
         //@formatter:on
 
@@ -113,8 +113,8 @@ public class HashAggregateTest extends APhysicalPlanTest
                                     new FunctionCallExpression("", SystemCatalog.get().getScalarFunction("count"), null, asList(col1)),
                                     new AggregateWrapperExpression(col2, false, false),
                                     new FunctionCallExpression("", SystemCatalog.get().getScalarFunction("sum"), null, asList(col1)),
-                                    new AggregateWrapperExpression(new ArithmeticBinaryExpression(IArithmeticBinaryExpression.Type.ADD, col1, col2), false, false))
-                                    ),
+                                    new AggregateWrapperExpression(new ArithmeticBinaryExpression(IArithmeticBinaryExpression.Type.ADD, col1, col2), false, false)),
+                                    null),
                 asList(sortItem(ce("count", 0), Order.ASC, NullOrder.UNDEFINED)));
         //@formatter:on
 
@@ -238,7 +238,8 @@ public class HashAggregateTest extends APhysicalPlanTest
                 .getScalarFunction("count"), null, asList(col1)), new FunctionCallExpression("",
                         SystemCatalog.get()
                                 .getScalarFunction("sum"),
-                        null, asList(col1))));
+                        null, asList(col1))),
+                null);
 
         for (int i = 0; i < 1; i++)
         {

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/NestedLoopTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/NestedLoopTest.java
@@ -420,7 +420,8 @@ public class NestedLoopTest extends AJoinTest
                               col4,
                               new AliasExpression(new ArithmeticBinaryExpression(IArithmeticBinaryExpression.Type.ADD, col1,
                                       new ArithmeticBinaryExpression(IArithmeticBinaryExpression.Type.ADD, col1, col2)), "oCalc")
-                            )),
+                            ),
+                            null),
                         outerReferences,
                         null,
                         outerSchemaLess);

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/ProjectionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/ProjectionTest.java
@@ -47,7 +47,7 @@ public class ProjectionTest extends APhysicalPlanTest
 
         MutableBoolean closed = new MutableBoolean(false);
         IPhysicalPlan plan = new Projection(1, scan(schemaDS(() -> closed.setTrue(), tv), table, Schema.EMPTY),
-                asList(col1, new ComparisonExpression(IComparisonExpression.Type.GREATER_THAN_EQUAL, col1, col3), col3));
+                asList(col1, new ComparisonExpression(IComparisonExpression.Type.GREATER_THAN_EQUAL, col1, col3), col3), null);
 
         //@formatter:off
         Schema expectedSchema = Schema.of(
@@ -148,7 +148,7 @@ public class ProjectionTest extends APhysicalPlanTest
             }
         };
 
-        IPhysicalPlan plan = new Projection(1, input, asList(aastExp, bcol3Exp, calcExp));
+        IPhysicalPlan plan = new Projection(1, input, asList(aastExp, bcol3Exp, calcExp), null);
 
         // Asterisks => empty schema
         //@formatter:off
@@ -216,7 +216,7 @@ public class ProjectionTest extends APhysicalPlanTest
         };
 
         MutableBoolean closed = new MutableBoolean(false);
-        IPhysicalPlan plan = new Projection(1, scan(schemaDS(() -> closed.setTrue(), tv), table, Schema.EMPTY), asList(col1, col3, ocol4));
+        IPhysicalPlan plan = new Projection(1, scan(schemaDS(() -> closed.setTrue(), tv), table, Schema.EMPTY), asList(col1, col3, ocol4), null);
 
         Schema outerSchema = schema("col4");
 

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/QueryPlannerTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/QueryPlannerTest.java
@@ -126,7 +126,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
 
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
 
@@ -175,7 +175,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
 
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
 
@@ -233,7 +233,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA = new TableSourceReference(3, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
 
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
 
@@ -241,7 +241,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan expected = new Projection(
                 1,
                 new TableScan(0, expectedSchemaA, tableA, "test", false, t.scanDataSources.get(0), emptyList()),
-                List.of(cre("col1", tableA), cre("col2", tableA))
+                List.of(cre("col1", tableA), cre("col2", tableA)),
+                null
                 );
         //@formatter:on
 
@@ -279,14 +280,15 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
 
         //@formatter:off
         IPhysicalPlan expected = new Projection(
                 2,
                 new TableScan(0, expectedSchemaA, tableA, "test", false, t.scanDataSources.get(0), emptyList()),
-                List.of(cre("col1", tableA), cre("col2", tableA), add(cre("col3", tableA), cre("col2", tableA)))
+                List.of(cre("col1", tableA), cre("col2", tableA), add(cre("col3", tableA), cre("col2", tableA))),
+                null
                 );
         //@formatter:on
 
@@ -325,7 +327,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
 
         //@formatter:off
@@ -340,7 +342,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
                                 1,
                                 new TableScan(0, expectedSchemaA, tableA, "test", false, t.scanDataSources.get(0), emptyList())
                             ),
-                            List.of(cre("col1", tableA), cre("col2", tableA), add(cre("col3", tableA), cre("col2", tableA)))
+                            List.of(cre("col1", tableA), cre("col2", tableA), add(cre("col3", tableA), cre("col2", tableA))),
+                            null
                         )
                     ),
                     true);
@@ -383,14 +386,15 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
 
         //@formatter:off
         IPhysicalPlan expected = new Projection(
                 2,
                 new TableScan(0, expectedSchemaA, tableA, "test", false, t.scanDataSources.get(0), emptyList()),
-                List.of(new AliasExpression(add(cre("col1", tableA), cre("col2", tableA)), "col"))
+                List.of(new AliasExpression(add(cre("col1", tableA), cre("col2", tableA)), "col")),
+                null
                 );
         //@formatter:on
 
@@ -435,8 +439,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
-        TableSourceReference tableA1 = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA1 = new TableSourceReference(3, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaA1 = Schema.of(ast("", ResolvedType.of(Type.Any), tableA1));
 
@@ -491,9 +495,9 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
-        TableSourceReference tableA1 = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
-        TableSourceReference subQueryT = new TableSourceReference(3, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("t"), "t");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA1 = new TableSourceReference(3, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference subQueryT = new TableSourceReference(2, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("t"), "t");
 
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaA1 = Schema.of(ast("", ResolvedType.of(Type.Any), tableA1));
@@ -505,7 +509,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 new Projection(
                   2,
                   new TableScan(1, expectedSchemaA1, tableA1, "test", false, t.scanDataSources.get(1), emptyList()),
-                  List.of(new AliasExpression(add(cre("col1", tableA1), cre("col2", tableA1)), "value"))),
+                  List.of(new AliasExpression(add(cre("col1", tableA1), cre("col2", tableA1)), "value")),
+                  subQueryT),
                 List.of(cre("value", tableA, ResolvedType.of(Type.Any))),
                 List.of(cre("value", subQueryT, ResolvedType.of(Type.Any), CoreColumn.Type.REGULAR)),
                 new ExpressionPredicate(eq(cre("value", subQueryT, ResolvedType.of(Type.Any), CoreColumn.Type.REGULAR), cre("value", tableA, ResolvedType.of(Type.Any)))),
@@ -552,10 +557,10 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
-        TableSourceReference tableA1 = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
-        TableSourceReference subQueryT = new TableSourceReference(3, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("t"), "t");
-        TableSourceReference subQueryF = new TableSourceReference(1, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("f"), "f");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA1 = new TableSourceReference(3, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference subQueryT = new TableSourceReference(2, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("t"), "t");
+        TableSourceReference subQueryF = new TableSourceReference(0, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("f"), "f");
 
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaA1 = Schema.of(ast("", ResolvedType.of(Type.Any), tableA1));
@@ -566,11 +571,13 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 new Projection(
                     1,
                     new TableScan(0, expectedSchemaA, tableA, "test", false, t.scanDataSources.get(0), emptyList()),
-                    List.of(new AliasExpression(add(cre("col3", tableA), cre("col4", tableA)), "value"))),
+                    List.of(new AliasExpression(add(cre("col3", tableA), cre("col4", tableA)), "value")),
+                    subQueryF),
                 new Projection(
                     3,
                     new TableScan(2, expectedSchemaA1, tableA1, "test", false, t.scanDataSources.get(1), emptyList()),
-                    List.of(new AliasExpression(add(cre("col1", tableA1), cre("col2", tableA1)), "value"))),
+                    List.of(new AliasExpression(add(cre("col1", tableA1), cre("col2", tableA1)), "value")),
+                    subQueryT),
                 List.of(cre("value", subQueryF, 0)),
                 List.of(cre("value", subQueryT, 1)),
                 new ExpressionPredicate(eq(cre("value", subQueryT, 1), cre("value", subQueryF, 0))),
@@ -617,8 +624,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
         IPhysicalPlan actual = ((PhysicalSelectStatement) queryStatement.getStatements()
                 .get(0)).getSelect();
 
-        TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
-        TableSourceReference tableA1 = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
+        TableSourceReference tableA1 = new TableSourceReference(3, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "");
 
         Schema expectedSchemaA = Schema.of(ast("", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaA1 = Schema.of(ast("", ResolvedType.of(Type.Any), tableA1));
@@ -669,7 +676,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 .get(0)).getSelect();
 
         TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
-        TableSourceReference tableB = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
+        TableSourceReference tableB = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
 
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
@@ -719,7 +726,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 .get(0)).getSelect();
 
         TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
-        TableSourceReference tableB = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
+        TableSourceReference tableB = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
 
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
@@ -770,7 +777,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 .get(0)).getSelect();
 
         TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
-        TableSourceReference tableB = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
+        TableSourceReference tableB = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
 
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
@@ -1336,12 +1343,14 @@ public class QueryPlannerTest extends APhysicalPlanTest
                                 new Projection(
                                     2,
                                     new TableScan(1, expectedSchemaB, tableB, "test", false, t.scanDataSources.get(1), emptyList()),
-                                    asList(new AliasExpression(cre("col1", tableB), "__expr0", true))),
+                                    asList(new AliasExpression(cre("col1", tableB), "__expr0", true)),
+                                    null),
                                 1)
                         ),
                     null,
                     false),
-                asList(new AsteriskExpression(QualifiedName.EMPTY, null, Set.of(tableA)), new AliasExpression(cre("__expr0", tableB), "values")));
+                asList(new AsteriskExpression(QualifiedName.EMPTY, null, Set.of(tableA)), new AliasExpression(cre("__expr0", tableB), "values")),
+                null);
         //@formatter:on
 
         // System.out.println(actual.print(0));
@@ -1416,7 +1425,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
                                 e_b,
                                 e_bExpectedSchema,
                                 ocre("b", tableB, ResolvedType.table(expectedSchemaB), CoreColumn.Type.POPULATED)),
-                            asList(cre("col1", e_b), cre("col2", e_b))),
+                            asList(cre("col1", e_b), cre("col2", e_b)),
+                            null),
                         SystemCatalog.get().getOperatorFunction("object_array"),
                         "sys",
                         Schema.of(col("__expr0", ResolvedType.table(objectArraySchema), null, true))),
@@ -1424,7 +1434,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
                     null,
                     SchemaUtils.joinSchema(expectedSchemaA, expectedSchemaB, "b")),
                 asList(new AsteriskExpression(QualifiedName.EMPTY, null, Set.of(tableA, tableB)),
-                        new AliasExpression(ce("__expr0", ResolvedType.table(objectArraySchema)), "values")));
+                        new AliasExpression(ce("__expr0", ResolvedType.table(objectArraySchema)), "values")),
+                null);
         //@formatter:on
 
         // System.out.println(actual.print(0));
@@ -2314,9 +2325,9 @@ public class QueryPlannerTest extends APhysicalPlanTest
                 .get(0)).getSelect();
 
         TableSourceReference tableA = new TableSourceReference(0, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableA"), "a");
-        TableSourceReference tableB = new TableSourceReference(1, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
-        TableSourceReference tableC = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableC"), "c");
-        TableSourceReference subQueryB = new TableSourceReference(3, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("b"), "b");
+        TableSourceReference tableB = new TableSourceReference(2, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableB"), "b");
+        TableSourceReference tableC = new TableSourceReference(3, TableSourceReference.Type.TABLE, "", QualifiedName.of("tableC"), "c");
+        TableSourceReference subQueryB = new TableSourceReference(1, TableSourceReference.Type.SUBQUERY, "", QualifiedName.of("b"), "b");
 
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
@@ -2357,7 +2368,8 @@ public class QueryPlannerTest extends APhysicalPlanTest
                                         new FunctionCallExpression("sys", SystemCatalog.get().getScalarFunction("count"), null, asList(intLit(1))),
                                         intLit(0)),
                                     "active"), true, false)
-                        )
+                        ),
+                       subQueryB
                     ),
                 List.of(cre("col", tableA)),
                 List.of(cre("col", tableB, CoreColumn.Type.REGULAR)),

--- a/payloadbuilder-core/src/test/resources/harnessCases/BaseContructs.json
+++ b/payloadbuilder-core/src/test/resources/harnessCases/BaseContructs.json
@@ -1222,6 +1222,7 @@
         "Make sure that the calculated column inside subquery in used in the join predicate"
       ],
       "query": [
+        "--set @@debugplan = true ",
         "select *",
         "from source s",
         "inner join ",
@@ -1952,6 +1953,52 @@
       ]
     },
     {
+      "name": "Table values ctor with outer references 2",
+      "query": [
+        "--set @@debugplan = true ",
+        "select y.* ",
+        "from source s ",
+        "outer apply ( ",
+        "  values (s.col1, s.col2) ",
+        ") y (col3, col4) "
+      ],
+      "expectedResultSets": [
+        [
+          [ { "key": "col3", "value": 1}, { "key": "col4", "value": 2}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": 4}],
+          [ { "key": "col3", "value": 5}, { "key": "col4", "value": 6}]
+        ]
+      ]
+    },
+    {
+      "name": "Table values ctor with outer references 3",
+      "query": [
+        "--set @@debugplan = true ",
+        "select y.* ",
+        "from source s ",
+        "inner join data d ",
+        "  on d.id = s.col1 ",
+        "outer apply ( ",
+        "  values (s.col1, s.col2) ",
+        "  ,      (d.id,   d.data) ", 
+        ") y (col3, col4) "
+      ],
+      "expectedResultSets": [
+        [
+          [ { "key": "col3", "value": 1}, { "key": "col4", "value": 2}],
+          [ { "key": "col3", "value": 1}, { "key": "col4", "value": "1_1"}],
+          [ { "key": "col3", "value": 1}, { "key": "col4", "value": 2}],
+          [ { "key": "col3", "value": 1}, { "key": "col4", "value": "1_2"}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": 4}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": "3_1"}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": 4}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": "3_2"}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": 4}],
+          [ { "key": "col3", "value": 3}, { "key": "col4", "value": "3_3"}]
+        ]
+      ]
+    },
+    {
       "name": "Table values ctor multiple",
       "query": [
         "--set @@debugplan = true ",
@@ -2027,7 +2074,7 @@
         ") y ",
         "outer apply ( ",
         "  select 3 col1, 4 col2 ",
-        ") z  "
+        ") z "
       ],
       "expectedResultSets": [
         [


### PR DESCRIPTION
…eird construct.

fix: Now a subQuery table source is tagged on expressions / columns that lacks during resolving to make expression evaluation more robust