### PR TITLE
fix: Fix issue where push down predicates wasn't pushed down inside a…

### DIFF
--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/execution/UTF8String.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/execution/UTF8String.java
@@ -33,6 +33,8 @@ public class UTF8String implements Comparable<UTF8String>, ValueVector
 
     private String string;
 
+    private boolean hashIsZero;
+    private int hash;
     private byte[] bytes;
     private int offset;
     private int length;
@@ -135,12 +137,26 @@ public class UTF8String implements Comparable<UTF8String>, ValueVector
         // hash code from string and bytes since then hash match don't work
         getBytesInternal();
 
-        // TODO: cache
-        int result = START;
-        final int end = offset + length;
-        for (int i = offset; i < end; i++)
+        int result = hash;
+        if (hash == 0
+                && !hashIsZero)
         {
-            result = result * CONSTANT + bytes[i];
+            result = START;
+            int end = offset + length;
+            for (int i = offset; i < end; i++)
+            {
+                result = result * CONSTANT + bytes[i];
+            }
+
+            if (result == 0)
+            {
+                hashIsZero = true;
+            }
+            else
+            {
+                hash = result;
+            }
+
         }
         return result;
     }

--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/expression/IExpression.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/expression/IExpression.java
@@ -84,6 +84,30 @@ public interface IExpression
         return null;
     }
 
+    /**
+     * Returns true if this expression is a pointer to an outer reference. This is true for expressions that are located inside a correlated
+     * construct (subquery) and hence references something outside of the current scope. For example when building a query for a catalog implementation
+     * regarding predicates this is crucial to know since this expression is constant in that sense and can indeed be used as pushed down predicate.
+     *
+     * <pre>
+     * Example:
+     *
+     * select *
+     * from tableA a
+     * outer apply (
+     *      select *
+     *      from tableB b
+     *      where b.col1 = a.col1           <----- Here a.col1 is an outer reference and can be used as a predicate
+     *                                             for tableB since inside the subquery that expression can be seen as constant
+     * ) x
+     *
+     * </pre>
+     */
+    default boolean isOuterReference()
+    {
+        return false;
+    }
+
     /** Return a verbose string that can be used in plan printing etc. for easier debugging. */
     default String toVerboseString()
     {

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/ESDatasource.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/ESDatasource.java
@@ -139,7 +139,7 @@ class ESDatasource implements IDatasource
                         sortItems.stream()
                                 .map(Object::toString)
                                 .collect(joining(", "))),
-                entry("Query", ESQueryUtils.getSearchBody(strategy, sortItems, propertyPredicates, null, indexField, quoteValues, context)));
+                entry("Query", ESQueryUtils.getSearchBody(true, strategy, sortItems, propertyPredicates, null, indexField, quoteValues, context)));
 
         Data data = context.getStatementContext()
                 .getNodeData(nodeId);
@@ -189,7 +189,7 @@ class ESDatasource implements IDatasource
 
         boolean quoteValues = indexProperty == null
                 || indexProperty.shouldQuoteValues();
-        String body = ESQueryUtils.getSearchBody(strategy, sortItems, propertyPredicates, indexSeekValues, indexField, quoteValues, context);
+        String body = ESQueryUtils.getSearchBody(false, strategy, sortItems, propertyPredicates, indexSeekValues, indexField, quoteValues, context);
         data.actualQuery = body;
         return getScrollingIterator(context, strategy, catalogAlias, esType.endpoint, data, searchUrl, scrollUrl, body);
     }

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/ESQueryUtils.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/ESQueryUtils.java
@@ -94,18 +94,18 @@ final class ESQueryUtils
     }
 
     /** Build search body **/
-    static String getSearchBody(ElasticStrategy strategy, List<SortItemMeta> sortItems, List<IPropertyPredicate> propertyPredicates, ValueVector indexSeekValues, String indexField,
+    static String getSearchBody(boolean describe, ElasticStrategy strategy, List<SortItemMeta> sortItems, List<IPropertyPredicate> propertyPredicates, ValueVector indexSeekValues, String indexField,
             boolean quoteIndexFieldValues, IExecutionContext context)
     {
         StringBuilder sb = new StringBuilder().append('{');
         appendSortItems(strategy, sortItems, sb);
-        appendPropertyPredicates(strategy, propertyPredicates, indexSeekValues, indexField, quoteIndexFieldValues, sb, context);
+        appendPropertyPredicates(describe, strategy, propertyPredicates, indexSeekValues, indexField, quoteIndexFieldValues, sb, context);
         sb.append('}');
         return sb.toString();
     }
 
-    private static void appendPropertyPredicates(ElasticStrategy strategy, List<IPropertyPredicate> propertyPredicates, ValueVector indexSeekValues, String indexField, boolean quoteIndexFieldValues,
-            StringBuilder sb, IExecutionContext context)
+    private static void appendPropertyPredicates(boolean describe, ElasticStrategy strategy, List<IPropertyPredicate> propertyPredicates, ValueVector indexSeekValues, String indexField,
+            boolean quoteIndexFieldValues, StringBuilder sb, IExecutionContext context)
     {
         StringBuilder filterMust = new StringBuilder();
         StringBuilder filterMustNot = new StringBuilder();
@@ -122,7 +122,7 @@ final class ESQueryUtils
             int length = sbs.size();
             for (IPropertyPredicate predicate : propertyPredicates)
             {
-                predicate.appendBooleanClause(strategy, filterMust, filterMustNot, context);
+                predicate.appendBooleanClause(describe, strategy, filterMust, filterMustNot, context);
 
                 for (int i = 0; i < length; i++)
                 {

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/IPropertyPredicate.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/IPropertyPredicate.java
@@ -13,6 +13,6 @@ interface IPropertyPredicate
 
     String getDescription();
 
-    void appendBooleanClause(ElasticStrategy strategy, StringBuilder filterMust, StringBuilder filterMustNot, IExecutionContext context);
+    void appendBooleanClause(boolean describe, ElasticStrategy strategy, StringBuilder filterMust, StringBuilder filterMustNot, IExecutionContext context);
 }
 // CSON

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/MatchFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/MatchFunction.java
@@ -21,6 +21,12 @@ class MatchFunction extends ScalarFunctionInfo
     }
 
     @Override
+    public Arity arity()
+    {
+        return Arity.TWO;
+    }
+
+    @Override
     public String getDescription()
     {
         return "Function that is used in Elastic search query context (predicates) and utilizes Elastic 'match/multi_match' query. " + System.lineSeparator()

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/PropertyPredicate.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/PropertyPredicate.java
@@ -73,7 +73,7 @@ class PropertyPredicate implements IPropertyPredicate
     }
 
     @Override
-    public void appendBooleanClause(ElasticStrategy strategy, StringBuilder filterMust, StringBuilder filterMustNot, IExecutionContext context)
+    public void appendBooleanClause(boolean describe, ElasticStrategy strategy, StringBuilder filterMust, StringBuilder filterMustNot, IExecutionContext context)
     {
         if (predicate.getType() == IPredicate.Type.COMPARISION)
         {

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/QueryFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/QueryFunction.java
@@ -21,6 +21,12 @@ class QueryFunction extends ScalarFunctionInfo
     }
 
     @Override
+    public Arity arity()
+    {
+        return Arity.ONE;
+    }
+
+    @Override
     public String getDescription()
     {
         return "Function that is used in Elastic search query context (predicates) and utilizes Elastic 'query_string' query. " + System.lineSeparator()

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/es/ESQueryUtilsTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/es/ESQueryUtilsTest.java
@@ -131,7 +131,7 @@ public class ESQueryUtilsTest extends Assert
 
         // Null outer values should yield a dummy value
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"terms\":{\"index.keyword\":[\"<index values>\"]}}],\"must_not\":[{\"term\":{\"field1\":20}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, "index.keyword", true, context));
@@ -140,14 +140,14 @@ public class ESQueryUtilsTest extends Assert
 
         // Non quote
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"terms\":{\"index.keyword\":[1,2]}}],\"must_not\":[{\"term\":{\"field1\":20}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), indexSeekValues, "index.keyword", false, context));
 
         // Quote
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"terms\":{\"index.keyword\":[\"1\",\"2\"]}}],\"must_not\":[{\"term\":{\"field1\":20}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), indexSeekValues, "index.keyword", true, context));
@@ -156,12 +156,12 @@ public class ESQueryUtilsTest extends Assert
     @Test
     public void test_search_body_singleType()
     {
-        assertEquals("{\"sort\":[\"_doc\"]}", ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), emptyList(), null, null, false, context));
+        assertEquals("{\"sort\":[\"_doc\"]}", ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), emptyList(), null, null, false, context));
         assertEquals(
                 // CSOFF
                 "{\"sort\":[{\"@timestamp\":{\"order\":\"desc\",\"missing\":\"_last\"}},{\"count\":{\"order\":\"asc\"}},{\"nested.object.value\":{\"order\":\"asc\",\"nested\":{\"path\":\"nested.object\"}}},{\"text.keyword\":{\"order\":\"asc\"}}]}",
                 // CSON
-                ESQueryUtils.getSearchBody(new GenericStrategy(), asList(
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), asList(
                         // Null order
                         sortItem("@timestamp", "int", null, Order.DESC, NullOrder.LAST),
                         // No null order
@@ -176,27 +176,27 @@ public class ESQueryUtilsTest extends Assert
                 // CSOFF
                 "{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"wildcard\":{\"field4\":{\"value\":\"other*string?end\"}}},{\"wildcard\":{\"field3\":{\"value\":\"some*string?end\"}}},{\"terms\":{\"field\":[1,2,3]}},{\"term\":{\"count\":10}},{\"range\":{\"timestamp\":{\"lte\":\"20201010T10:10:10:000Z\"}}},{\"range\":{\"timestamp\":{\"gte\":\"20201010T10:10:10:000Z\"}}},{\"range\":{\"timestamp\":{\"lt\":\"20201010T10:10:10:000Z\"}}},{\"range\":{\"timestamp\":{\"gt\":\"20201010T10:10:10:000Z\"}}}],\"must_not\":[{\"terms\":{\"field7\":[4,5,6]}},{\"wildcard\":{\"field6\":{\"value\":\"other?string*end\"}}},{\"wildcard\":{\"field5\":{\"value\":\"some?string*end\"}}},{\"term\":{\"field2\":true}},{\"term\":{\"field1\":20}}]}}}",
                 // CSON
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.neq("field1", 20));
-        assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"must_not\":[{\"term\":{\"field1\":20}}]}}}", ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+        assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"must_not\":[{\"term\":{\"field1\":20}}]}}}", ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                 .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                         .toString(), p, false))
                 .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.notLike("field5", "some_string%end"));
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"must_not\":[{\"wildcard\":{\"field5\":{\"value\":\"some?string*end\"}}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.like("field4", "other%string_end"));
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"wildcard\":{\"field4\":{\"value\":\"other*string?end\"}}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
@@ -206,9 +206,10 @@ public class ESQueryUtilsTest extends Assert
         assertTrue(PropertyPredicate.isSupported(pairs.get(0), "es"));
         assertFalse(PropertyPredicate.isSupported(pairs.get(0), "sys"));
 
-        assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"match\":{\"field4\":\"some phrase\"}}]}}}", ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
-                .map(p -> new PropertyPredicate("", p, true))
-                .collect(toList()), null, null, false, context));
+        assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"match\":{\"field4\":\"some phrase\"}}]}}}",
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
+                        .map(p -> new PropertyPredicate("", p, true))
+                        .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.function("es", "query", asList("field4:'some phrase'")));
 
@@ -216,13 +217,13 @@ public class ESQueryUtilsTest extends Assert
         assertFalse(PropertyPredicate.isSupported(pairs.get(0), "sys"));
 
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"query_string\":{\"query\":\"field4:'some phrase'\"}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate("", p, true))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock._null("field1", false), IPredicateMock._null("field2", true));
         assertEquals("{\"sort\":[\"_doc\"],\"query\":{\"bool\":{\"filter\":[{\"exists\":{\"field\":\"field2\"}}],\"must_not\":[{\"exists\":{\"field\":\"field1\"}}]}}}",
-                ESQueryUtils.getSearchBody(new GenericStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new GenericStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
@@ -237,14 +238,14 @@ public class ESQueryUtilsTest extends Assert
         List<IPredicate> pairs = asList(IPredicateMock.neq("field1", 20));
         // Non quote
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"terms\":{\"index.keyword\":[1,2]}}],\"must_not\":[{\"term\":{\"field1\":20}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), indexSeekValues, "index.keyword", false, context));
 
         // Quote
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"terms\":{\"index.keyword\":[\"1\",\"2\"]}}],\"must_not\":[{\"term\":{\"field1\":20}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), indexSeekValues, "index.keyword", true, context));
@@ -253,12 +254,12 @@ public class ESQueryUtilsTest extends Assert
     @Test
     public void test_search_body()
     {
-        assertEquals("{\"sort\":[\"_doc\"]}", ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), emptyList(), null, null, false, context));
+        assertEquals("{\"sort\":[\"_doc\"]}", ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), emptyList(), null, null, false, context));
         assertEquals(
                 // CSOFF
                 "{\"sort\":[{\"@timestamp\":{\"order\":\"desc\",\"missing\":\"_first\"}},{\"count\":{\"order\":\"asc\"}},{\"nested.object.value\":{\"order\":\"asc\",\"nested_path\":\"nested.object\"}},{\"text.raw\":{\"order\":\"asc\"}}]}",
                 // CSON
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), asList(
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), asList(
                         // Null order
                         sortItem("@timestamp", "int", null, Order.DESC, NullOrder.FIRST),
                         // No null order
@@ -273,33 +274,33 @@ public class ESQueryUtilsTest extends Assert
                 // CSOFF
                 "{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"wildcard\":{\"field4\":{\"value\":\"other*string?end\"}}},{\"wildcard\":{\"field3\":{\"value\":\"some*string?end\"}}},{\"terms\":{\"field\":[1,2,3]}},{\"term\":{\"count\":10}},{\"range\":{\"timestamp\":{\"lte\":\"20201010T10:10:10:000Z\"}}},{\"range\":{\"timestamp\":{\"gte\":\"20201010T10:10:10:000Z\"}}},{\"range\":{\"timestamp\":{\"lt\":\"20201010T10:10:10:000Z\"}}},{\"range\":{\"timestamp\":{\"gt\":\"20201010T10:10:10:000Z\"}}}],\"must_not\":[{\"terms\":{\"field7\":[4,5,6]}},{\"wildcard\":{\"field6\":{\"value\":\"other?string*end\"}}},{\"wildcard\":{\"field5\":{\"value\":\"some?string*end\"}}},{\"term\":{\"field2\":true}},{\"term\":{\"field1\":20}}]}}}",
                 // CSON
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.neq("field1", 20));
-        assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must_not\":[{\"term\":{\"field1\":20}}]}}}", ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+        assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must_not\":[{\"term\":{\"field1\":20}}]}}}", ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                 .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                         .toString(), p, false))
                 .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.eq("field1", 20));
-        assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"term\":{\"field1\":20}}]}}}", ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+        assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"term\":{\"field1\":20}}]}}}", ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                 .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                         .toString(), p, false))
                 .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.notLike("field5", "some_string%end"));
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must_not\":[{\"wildcard\":{\"field5\":{\"value\":\"some?string*end\"}}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.like("field4", "other%string_end"));
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"wildcard\":{\"field4\":{\"value\":\"other*string?end\"}}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));
@@ -309,25 +310,25 @@ public class ESQueryUtilsTest extends Assert
 
         pairs = asList(IPredicateMock.function("es", "match", asList(col, "some phrase")));
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"match\":{\"field4\":\"some phrase\"}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate("", p, true))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.function("es", "match", asList("field4,field5", "some phrase")));
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"multi_match\":{\"fields\":[\"field4\",\"field5\"],\"query\":\"some phrase\"}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate("", p, true))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock.function("es", "query", asList("field4:'some phrase'")));
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"query_string\":{\"query\":\"field4:'some phrase'\"}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate("", p, true))
                         .collect(toList()), null, null, false, context));
 
         pairs = asList(IPredicateMock._null("field1", false), IPredicateMock._null("field2", true));
         assertEquals("{\"sort\":[\"_doc\"],\"filter\":{\"bool\":{\"must\":[{\"exists\":{\"field\":\"field2\"}}],\"must_not\":[{\"exists\":{\"field\":\"field1\"}}]}}}",
-                ESQueryUtils.getSearchBody(new Elastic1XStrategy(), emptyList(), pairs.stream()
+                ESQueryUtils.getSearchBody(false, new Elastic1XStrategy(), emptyList(), pairs.stream()
                         .map(p -> new PropertyPredicate(p.getQualifiedColumn()
                                 .toString(), p, false))
                         .collect(toList()), null, null, false, context));

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/QueryResult.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/QueryResult.java
@@ -3,9 +3,8 @@ package se.kuseman.payloadbuilder.core;
 import se.kuseman.payloadbuilder.api.OutputWriter;
 
 /**
- * Definition of a query result. This interface is an implementation of iterator pattern where
- * the client traverses all produced result sets in a while-mode fashion checking for {{@link #hasMoreResults()}
- * and then writing to an output via {{@link #writeResult(OutputWriter)}.
+ * Definition of a query result. This interface is an implementation of iterator pattern where the client traverses all produced result sets in a while-mode fashion checking for
+ * {{@link #hasMoreResults()} and then writing to an output via {{@link #writeResult(OutputWriter)}.
  *
  * <pre>
  *  OutputWriter writer = ......

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/execution/StatementContext.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/execution/StatementContext.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -50,7 +51,7 @@ public class StatementContext implements IStatementContext
     /** Reference to outer tuple used in index seek operations where the inner operator picks it's values from. */
     private TupleVector indexSeekTupleVector;
     /** Cache of seeks keys for index seek predicate. Used to avoid multiple calculations if called twice. */
-    private List<ISeekPredicate.ISeekKey> indexSeekKeys;
+    private Map<Integer, List<ISeekPredicate.ISeekKey>> indexSeekKeysByTableSourceReferenceId;
 
     public StatementContext()
     {
@@ -88,7 +89,7 @@ public class StatementContext implements IStatementContext
         lambdaValues = null;
         nodeDataById.clear();
         indexSeekTupleVector = null;
-        indexSeekKeys = null;
+        indexSeekKeysByTableSourceReferenceId = null;
     }
 
     public Map<Integer, ? extends NodeData> getNodeData()
@@ -165,17 +166,27 @@ public class StatementContext implements IStatementContext
         }
 
         this.indexSeekTupleVector = indexSeekTupleVector;
-        this.indexSeekKeys = null;
+        this.indexSeekKeysByTableSourceReferenceId = null;
     }
 
-    public List<ISeekPredicate.ISeekKey> getIndexSeekKeys()
+    /** Get seek keys for provided table source id. */
+    public List<ISeekPredicate.ISeekKey> getIndexSeekKeys(int tableSourceReferenceId)
     {
-        return indexSeekKeys;
+        if (indexSeekKeysByTableSourceReferenceId == null)
+        {
+            indexSeekKeysByTableSourceReferenceId = new HashMap<>();
+        }
+        return indexSeekKeysByTableSourceReferenceId.get(tableSourceReferenceId);
     }
 
-    public void setIndexSeekKeys(List<ISeekKey> indexSeekKeys)
+    /** Store seek keys for provided table source id. */
+    public void setIndexSeekKeys(int tableSourceReferenceId, List<ISeekKey> indexSeekKeys)
     {
-        this.indexSeekKeys = indexSeekKeys;
+        if (this.indexSeekKeysByTableSourceReferenceId == null)
+        {
+            this.indexSeekKeysByTableSourceReferenceId = new HashMap<>();
+        }
+        indexSeekKeysByTableSourceReferenceId.put(tableSourceReferenceId, indexSeekKeys);
     }
 
     /**

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/ColumnExpression.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/ColumnExpression.java
@@ -111,6 +111,7 @@ public class ColumnExpression implements IColumnExpression, HasAlias, HasColumnR
         return ordinal;
     }
 
+    @Override
     public boolean isOuterReference()
     {
         return outerReference;

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/DereferenceExpression.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/expression/DereferenceExpression.java
@@ -72,6 +72,12 @@ public class DereferenceExpression implements IDereferenceExpression, HasAlias, 
         return right;
     }
 
+    @Override
+    public boolean isOuterReference()
+    {
+        return left.isOuterReference();
+    }
+
     public int getOrdinal()
     {
         return ordinal;

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ColumnResolver.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ColumnResolver.java
@@ -122,9 +122,8 @@ class ColumnResolver extends ALogicalPlanOptimizer<ColumnResolver.Ctx>
         Deque<TableSourceReference> subQueryTableSource = new ArrayDeque<>();
 
         /**
-         * Set with expanded aggregated asterisks. This is used to to skip resolving those since an
-         * expanded asterisk should NOTE be a single value to match a schema less query which would make
-         * those columns arrays.
+         * Set with expanded aggregated asterisks. This is used to to skip resolving those since an expanded asterisk should NOTE be a single value to match a schema less query which would make those
+         * columns arrays.
          *
          * <pre>
          * Ie.

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/physicalplan/TableScan.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/physicalplan/TableScan.java
@@ -21,6 +21,7 @@ import se.kuseman.payloadbuilder.api.execution.ValueVector;
 import se.kuseman.payloadbuilder.core.QueryException;
 import se.kuseman.payloadbuilder.core.catalog.TableSourceReference;
 import se.kuseman.payloadbuilder.core.common.SchemaUtils;
+import se.kuseman.payloadbuilder.core.execution.StatementContext;
 
 /** Scan operator that scans datasource */
 public class TableScan implements IPhysicalPlan
@@ -81,7 +82,10 @@ public class TableScan implements IPhysicalPlan
     public TupleIterator execute(IExecutionContext context)
     {
         final int batchSize = context.getBatchSize(options);
+        final StatementContext statementContext = (StatementContext) context.getStatementContext();
         final TupleIterator iterator = datasource.execute(context);
+        // Clear any seek keys after we executed the data source to make sure they are not misused
+        statementContext.setIndexSeekKeys(tableSource.getId(), null);
         return new TupleIterator()
         {
             @Override

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/ConditionAnalyzer.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/planning/ConditionAnalyzer.java
@@ -115,7 +115,8 @@ class ConditionAnalyzer
             List<SeekPredicateItem> items = IntStream.range(0, size)
                     .mapToObj(i -> new SeekPredicate.SeekPredicateItem(splitResult.indexColumns.get(i), innerValueExpressions.get(i), List.of(outerValueExpressions.get(i))))
                     .toList();
-            return new SeekPredicate(splitResult.index, items, true);
+            return new SeekPredicate(scan.getTableSource()
+                    .getId(), splitResult.index, items, true);
         }
 
         // Try IN pairs
@@ -134,7 +135,8 @@ class ConditionAnalyzer
                     IInExpression ine = (IInExpression) pair.getExpressionPair(tableSource)
                             .getValue();
                     List<SeekPredicateItem> items = singletonList(new SeekPredicate.SeekPredicateItem(column, ine.getExpression(), ine.getArguments()));
-                    return new SeekPredicate(index, items, true);
+                    return new SeekPredicate(scan.getTableSource()
+                            .getId(), index, items, true);
                 }
             }
         }
@@ -250,7 +252,7 @@ class ConditionAnalyzer
             List<SeekPredicateItem> items = IntStream.range(0, size)
                     .mapToObj(i -> new SeekPredicate.SeekPredicateItem(splitResult.indexColumns.get(i), innerValueExpressions.get(i), List.of(outerValueExpressions.get(i))))
                     .toList();
-            seekPredicate = new SeekPredicate(splitResult.index, items);
+            seekPredicate = new SeekPredicate(tableSource.getId(), splitResult.index, items);
         }
         return new Result(outerValueExpressions, innerValueExpressions, seekPredicate);
     }

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/expression/AExpressionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/expression/AExpressionTest.java
@@ -47,6 +47,15 @@ public abstract class AExpressionTest extends Assert
         return new UnresolvedColumnExpression(QualifiedName.of(parts), -1, null);
     }
 
+    /** Return a simple reflective outer referenced column expression that resolve values runtime by name with type */
+    protected ColumnExpression oce(String col)
+    {
+        return ColumnExpression.Builder.of(col, ResolvedType.ANY)
+                .withColumn(col)
+                .withOuterReference(true)
+                .build();
+    }
+
     /** Return a simple reflective column expression that resolve values runtime by name */
     protected ColumnExpression ce(String col)
     {

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/expression/DereferenceExpressionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/expression/DereferenceExpressionTest.java
@@ -26,6 +26,19 @@ import se.kuseman.payloadbuilder.core.physicalplan.APhysicalPlanTest;
 public class DereferenceExpressionTest extends APhysicalPlanTest
 {
     @Test
+    public void test_outerreference()
+    {
+        IExpression e = DereferenceExpression.create(ce("a"), QualifiedName.of("b"), null);
+        assertFalse(e.isOuterReference());
+
+        e = DereferenceExpression.create(oce("a"), QualifiedName.of("b"), null);
+        assertTrue(e.isOuterReference());
+
+        e = DereferenceExpression.create(oce("a"), QualifiedName.of("b", "c"), null);
+        assertTrue(e.isOuterReference());
+    }
+
+    @Test
     public void test_dereference_map()
     {
         TupleVector tv;

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ALogicalPlanOptimizerTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ALogicalPlanOptimizerTest.java
@@ -124,10 +124,10 @@ public abstract class ALogicalPlanOptimizerTest extends ALogicalPlanTest
         session.setDefaultCatalogAlias(TEST);
     }
 
-    protected ILogicalPlan getPlanBeforeColumnResolver(String query)
+    protected ILogicalPlan getPlanBeforeRule(String query, Class<? extends ALogicalPlanOptimizer<?>> clazz)
     {
         ILogicalPlan plan = s(query);
-        return LogicalPlanOptimizer.optimizeInternal(context, plan, new HashMap<>(), new HashMap<>(), ColumnResolver.class);
+        return LogicalPlanOptimizer.optimizeInternal(context, plan, new HashMap<>(), new HashMap<>(), clazz);
     }
 
     protected ILogicalPlan getSchemaResolvedPlan(String query)

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ColumnResolverTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/logicalplan/optimization/ColumnResolverTest.java
@@ -395,7 +395,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 + "from tableA a";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -521,7 +521,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 + "  on b.col1 = a.col1 ";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -843,7 +843,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
         +"where id = 1";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
 
         try
         {
@@ -958,7 +958,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
 
         session.setCatalogProperty(TEST, STABLE_D_ID, 3);
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -1732,7 +1732,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 + "  on b.col2 = a.col2 ";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -1816,7 +1816,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 """;
         //@formatter:off
 
-        ILogicalPlan actual = getPlanBeforeColumnResolver(query);
+        ILogicalPlan actual = getPlanBeforeRule(query, ColumnResolver.class);
         actual = optimize(context, actual);
 
         //@formatter:off
@@ -1960,7 +1960,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 + "from tableA a ";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -2016,7 +2016,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 """;
         //@formatter:on
 
-        ILogicalPlan actual = getPlanBeforeColumnResolver(query);// optimize(context, plan);
+        ILogicalPlan actual = getPlanBeforeRule(query, ColumnResolver.class);// optimize(context, plan);
         actual = optimize(context, actual);
 
         //@formatter:off
@@ -2072,7 +2072,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 + "from tableA a ";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -2130,7 +2130,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                 + "from tableA a ";
         //@formatter:on
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");
@@ -3002,7 +3002,7 @@ public class ColumnResolverTest extends ALogicalPlanOptimizerTest
                        + ") x "
                        + "where x.col2 = a.col2 ";
 
-        ILogicalPlan plan = getPlanBeforeColumnResolver(query);
+        ILogicalPlan plan = getPlanBeforeRule(query, ColumnResolver.class);
         ILogicalPlan actual = optimize(context, plan);
 
         TableSourceReference tableA = of(0, "", "tableA", "a");

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/QueryPlannerTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/QueryPlannerTest.java
@@ -193,6 +193,9 @@ public class QueryPlannerTest extends APhysicalPlanTest
                     true);
         //@formatter:on
 
+        // System.out.println(actual.print(0));
+        // System.out.println(expected.print(0));
+
         Assertions.assertThat(actual)
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
@@ -1490,7 +1493,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
         
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(1,
                 new Index(QualifiedName.of("tableB"), asList("col"), ColumnsType.ANY_IN_ORDER), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(cre("col", tableA)))));
 
@@ -1731,7 +1734,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         //@formatter:off
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(0,
                 new Index(QualifiedName.of("tableB"), asList("col"), ColumnsType.ANY_IN_ORDER), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(intLit(1), intLit(2), intLit(3)))), true);
 
@@ -1788,7 +1791,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         //@formatter:off
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(0,
                 new Index(QualifiedName.of("tableB"), emptyList(), ColumnsType.WILDCARD), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(intLit(1), intLit(2), intLit(3)))), true);
 
@@ -1845,7 +1848,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         //@formatter:off
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(0,
                 new Index(QualifiedName.of("tableB"),  List.of("COL"), ColumnsType.ALL), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(intLit(1), intLit(2), intLit(3)))), true);
 
@@ -1904,7 +1907,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         //@formatter:off
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(0,
                 new Index(QualifiedName.of("tableB"), asList("col"), ColumnsType.ANY_IN_ORDER), List.of(
                         new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(intLit(3)))
                         ), true);
@@ -1969,7 +1972,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         //@formatter:off
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(index, List.of(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(0, index, List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(intLit(3))),
                 new SeekPredicate.SeekPredicateItem("col2", cre("col2", tableB), List.of(intLit(10)))
                 ), true);
@@ -2034,7 +2037,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         Schema expectedSchemaA = Schema.of(ast("a", ResolvedType.of(Type.Any), tableA));
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(1,
                 new Index(QualifiedName.of("tableB"), asList("col"), ColumnsType.ANY_IN_ORDER), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(cre("col", tableA)))));
         
@@ -2107,7 +2110,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
         //@formatter:off
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(1,
                 new Index(QualifiedName.of("tableB"), asList("col", "active"), ColumnsType.ALL), List.of(
                     new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(cre("col", tableA))),
                     new SeekPredicate.SeekPredicateItem("active", cre("active", tableB), List.of(cre("active", tableA)))));
@@ -2179,7 +2182,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
         //@formatter:off
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(1,
                 new Index(QualifiedName.of("tableB"), asList(), ColumnsType.WILDCARD), asList(
                 new SeekPredicate.SeekPredicateItem("active", cre("active", tableB), List.of(cre("active", tableA))),
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(cre("col", tableA)))));
@@ -2332,10 +2335,10 @@ public class QueryPlannerTest extends APhysicalPlanTest
         Schema expectedSchemaC = Schema.of(ast("c", ResolvedType.of(Type.Any), tableC));
 
         //@formatter:off
-        SeekPredicate expectedSeekPredicateB = new SeekPredicate(
+        SeekPredicate expectedSeekPredicateB = new SeekPredicate(2,
                 new Index(QualifiedName.of("tableB"), asList("col"), ColumnsType.ANY_IN_ORDER), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(cre("col", tableA)))));
-        SeekPredicate expectedSeekPredicateC = new SeekPredicate(
+        SeekPredicate expectedSeekPredicateC = new SeekPredicate(3,
                 new Index(QualifiedName.of("tableC"), asList("col"), ColumnsType.ANY_IN_ORDER), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableC), List.of(cre("col", tableB)))));
 
@@ -2440,7 +2443,7 @@ public class QueryPlannerTest extends APhysicalPlanTest
         Schema expectedSchemaB = Schema.of(ast("b", ResolvedType.of(Type.Any), tableB));
 
         //@formatter:off
-        SeekPredicate expectedSeekPredicate = new SeekPredicate(
+        SeekPredicate expectedSeekPredicate = new SeekPredicate(1,
                 new Index(QualifiedName.of("tableB"), asList("col", "col2"), ColumnsType.ANY_IN_ORDER), List.of(
                 new SeekPredicate.SeekPredicateItem("col", cre("col", tableB), List.of(cre("col", tableA))),
                 new SeekPredicate.SeekPredicateItem("col2", cre("col2", tableB), List.of(cre("col2", tableA)))));

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/SeekPredicateTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/planning/SeekPredicateTest.java
@@ -28,7 +28,7 @@ public class SeekPredicateTest extends APhysicalPlanTest
     public void test_fail_with_empty_items()
     {
         Index index = new Index(QualifiedName.of("table"), asList("col1", "col2"), ColumnsType.ANY);
-        new SeekPredicate(index, emptyList());
+        new SeekPredicate(0, index, emptyList());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class SeekPredicateTest extends APhysicalPlanTest
 
         List<SeekPredicate.SeekPredicateItem> items = List.of(new SeekPredicate.SeekPredicateItem("col1", colValue, List.of(colValue)));
 
-        SeekPredicate p = new SeekPredicate(index, items);
+        SeekPredicate p = new SeekPredicate(0, index, items);
 
         assertEquals(index, p.getIndex());
         assertEquals(asList("col1"), p.getIndexColumns());
@@ -67,7 +67,7 @@ public class SeekPredicateTest extends APhysicalPlanTest
 
         List<SeekPredicate.SeekPredicateItem> items = List.of(new SeekPredicate.SeekPredicateItem("col1", colValue, List.of(intLit(10))));
 
-        SeekPredicate p = new SeekPredicate(index, items, true);
+        SeekPredicate p = new SeekPredicate(0, index, items, true);
 
         assertEquals(index, p.getIndex());
         assertEquals(asList("col1"), p.getIndexColumns());
@@ -89,7 +89,7 @@ public class SeekPredicateTest extends APhysicalPlanTest
 
         List<SeekPredicate.SeekPredicateItem> items = List.of(new SeekPredicate.SeekPredicateItem("col1", colValue, List.of(stringLit("10"), intLit(20), intLit(30))));
 
-        SeekPredicate p = new SeekPredicate(index, items, true);
+        SeekPredicate p = new SeekPredicate(0, index, items, true);
 
         assertEquals(index, p.getIndex());
         assertEquals(asList("col1"), p.getIndexColumns());


### PR DESCRIPTION
… subquery

fix: Fix issue where index seek keys was re-used in wrong datasource caused by mutability in StatementContext, now instead we store the index keys connected to it's owning table source to avoid mis-usage.
fix(ESCatalog): Fix issue where outer referenced expressions wasn't used when pushing down predicates