### PR TITLE
fix: Remove Optional<Schema> argument to table function execute metho…

### DIFF
--- a/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/TableFunctionInfo.java
+++ b/payloadbuilder-api/src/main/java/se/kuseman/payloadbuilder/api/catalog/TableFunctionInfo.java
@@ -44,22 +44,25 @@ public abstract class TableFunctionInfo extends FunctionInfo
      * @see #execute(IExecutionContext, String, Optional, List, IDatasourceOptions, int)
      * @param nodeId The id of the functions node id the query plan tree. Can be used to get hold of node data from {@link IStatementContext} to store statistics during execution etc.
      */
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options, int nodeId)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options, int nodeId)
     {
-        return execute(context, catalogAlias, schema, arguments, options);
+        return execute(context, catalogAlias, arguments, options);
     }
 
     /**
      * Execute table function.
      *
+     * <pre>
+     * NOTE! If {{@link #getSchema(List,List)} returned a NON empty schema the {@link TupleVector}'s return from this {@link TupleIterator} MUST
+     * have the same set of columns regarding type and name.
+     * </pre>
+     *
      * @param context Execution context
      * @param catalogAlias The query specific catalog alias used in this invocation
-     * @param schema Planned schema for this table function. If this has a value then the schema should be used when returning {@link TupleVector}' from {@link TupleIterator}. Else value will be
-     * {@link Optional#empty()} and the actual runtime schema should be return for vectors.
      * @param arguments Function arguments
      * @param options Options for this table source such as batch size etc.
      */
-    public abstract TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options);
+    public abstract TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options);
 
     /**
      * Returns a map with describe properties that is used during describe/analyze statements

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/CatFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/CatFunction.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -53,7 +52,7 @@ class CatFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         String catspec;
         String endpoint;

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/SearchFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/es/SearchFunction.java
@@ -8,10 +8,8 @@ import static se.kuseman.payloadbuilder.catalog.es.ESQueryUtils.getSearchUrl;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import se.kuseman.payloadbuilder.api.catalog.Option;
-import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableFunctionInfo;
 import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
 import se.kuseman.payloadbuilder.api.execution.TupleIterator;
@@ -82,7 +80,7 @@ class SearchFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         String endpoint = null;
         String index = null;

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/fs/FilesystemCatalog.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/fs/FilesystemCatalog.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 
@@ -80,7 +79,7 @@ public class FilesystemCatalog extends Catalog
         }
 
         @Override
-        public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+        public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
         {
             ValueVector value = arguments.get(0)
                     .eval(context);
@@ -92,7 +91,7 @@ public class FilesystemCatalog extends Catalog
             Path path = FileSystems.getDefault()
                     .getPath(strPath);
             Object[] values = ListFunction.fromPath(path);
-            return TupleIterator.singleton(new ObjectTupleVector(schema.get(), 1, (row, col) -> values[col]));
+            return TupleIterator.singleton(new ObjectTupleVector(SCHEMA, 1, (row, col) -> values[col]));
         }
     }
 
@@ -190,7 +189,7 @@ public class FilesystemCatalog extends Catalog
         }
 
         @Override
-        public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+        public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
         {
             ValueVector value = arguments.get(0)
                     .eval(context);
@@ -261,7 +260,7 @@ public class FilesystemCatalog extends Catalog
                             @Override
                             public Schema getSchema()
                             {
-                                return schema.get();
+                                return SCHEMA;
                             }
 
                             @Override
@@ -278,8 +277,7 @@ public class FilesystemCatalog extends Catalog
                                     @Override
                                     public ResolvedType type()
                                     {
-                                        return schema.get()
-                                                .getColumns()
+                                        return SCHEMA.getColumns()
                                                 .get(column)
                                                 .getType();
                                     }

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/ATableFunctionForwardResponseTransformer.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/ATableFunctionForwardResponseTransformer.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -91,6 +90,6 @@ public abstract class ATableFunctionForwardResponseTransformer implements IRespo
             }
         };
 
-        return openJsonFunction.execute(context, Catalog.SYSTEM_CATALOG_ALIAS, Optional.empty(), List.of(arg), options);
+        return openJsonFunction.execute(context, Catalog.SYSTEM_CATALOG_ALIAS, List.of(arg), options);
     }
 }

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/QueryFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/http/QueryFunction.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -14,7 +13,6 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import se.kuseman.payloadbuilder.api.QualifiedName;
 import se.kuseman.payloadbuilder.api.catalog.Option;
-import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableFunctionInfo;
 import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
 import se.kuseman.payloadbuilder.api.execution.TupleIterator;
@@ -54,7 +52,7 @@ class QueryFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         /*
          * @formatter:off

--- a/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/QueryFunction.java
+++ b/payloadbuilder-catalog/src/main/java/se/kuseman/payloadbuilder/catalog/jdbc/QueryFunction.java
@@ -1,10 +1,8 @@
 package se.kuseman.payloadbuilder.catalog.jdbc;
 
 import java.util.List;
-import java.util.Optional;
 
 import se.kuseman.payloadbuilder.api.catalog.Option;
-import se.kuseman.payloadbuilder.api.catalog.Schema;
 import se.kuseman.payloadbuilder.api.catalog.TableFunctionInfo;
 import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
 import se.kuseman.payloadbuilder.api.execution.TupleIterator;
@@ -38,7 +36,7 @@ class QueryFunction extends TableFunctionInfo
 
     @SuppressWarnings("unchecked")
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         ValueVector queryVector = arguments.get(0)
                 .eval(context);

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/es/BaseESTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/es/BaseESTest.java
@@ -357,7 +357,7 @@ abstract class BaseESTest extends Assert
 
         IExecutionContext context = mockExecutionContext(CATALOG_ALIAS, ofEntries(entry("endpoint", endpoint), entry("index", INDEX)), 0, new ESDatasource.Data());
 
-        TupleIterator it = f.execute(context, CATALOG_ALIAS, Optional.empty(), asList(body), emptyList());
+        TupleIterator it = f.execute(context, CATALOG_ALIAS, asList(body), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -392,7 +392,7 @@ abstract class BaseESTest extends Assert
 
         IExecutionContext context = mockExecutionContext(CATALOG_ALIAS, ofEntries(entry("endpoint", endpoint), entry("index", INDEX)), 0, new ESDatasource.Data());
 
-        TupleIterator it = f.execute(context, CATALOG_ALIAS, Optional.empty(), asList(body, scroll), List.of(new Option(IExecutionContext.BATCH_SIZE, ExpressionTestUtils.createIntegerExpression(2))));
+        TupleIterator it = f.execute(context, CATALOG_ALIAS, asList(body, scroll), List.of(new Option(IExecutionContext.BATCH_SIZE, ExpressionTestUtils.createIntegerExpression(2))));
 
         int batchCount = 0;
         int rowCount = 0;
@@ -470,7 +470,7 @@ abstract class BaseESTest extends Assert
 
         IExecutionContext context = mockExecutionContext(CATALOG_ALIAS, ofEntries(entry("endpoint", endpoint), entry("index", INDEX)), 0, new ESDatasource.Data());
 
-        TupleIterator it = f.execute(context, CATALOG_ALIAS, Optional.empty(), asList(body, scroll), emptyList());
+        TupleIterator it = f.execute(context, CATALOG_ALIAS, asList(body, scroll), emptyList());
 
         int batchCount = 0;
         int rowCount = 0;
@@ -534,7 +534,7 @@ abstract class BaseESTest extends Assert
         IExpression catSpecArg = mock(IExpression.class);
         when(catSpecArg.eval(context)).thenReturn(VectorTestUtils.vv(Type.String, "/nodes"));
 
-        TupleIterator it = f.execute(context, CATALOG_ALIAS, Optional.empty(), asList(catSpecArg), emptyList());
+        TupleIterator it = f.execute(context, CATALOG_ALIAS, asList(catSpecArg), emptyList());
         int count = 0;
         while (it.hasNext())
         {

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/http/HttpCatalogTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/http/HttpCatalogTest.java
@@ -381,7 +381,7 @@ public class HttpCatalogTest
 
         try
         {
-            function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createNullExpression()), emptyList());
+            function.execute(context, "http", List.of(ExpressionTestUtils.createNullExpression()), emptyList());
             fail("Should fail");
         }
         catch (IllegalArgumentException e)
@@ -404,7 +404,7 @@ public class HttpCatalogTest
         assertEquals(Arity.ONE, function.arity());
 
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), emptyList());
+        TupleIterator it = function.execute(context, "http", List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -444,7 +444,7 @@ public class HttpCatalogTest
 
         try
         {
-            function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), emptyList());
+            function.execute(context, "http", List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())), emptyList());
             fail("Should fail");
         }
         catch (RuntimeException e)
@@ -466,7 +466,7 @@ public class HttpCatalogTest
 
         try
         {
-            function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:12345")), emptyList());
+            function.execute(context, "http", List.of(ExpressionTestUtils.createStringExpression("http://localhost:12345")), emptyList());
             fail("Should fail");
         }
         catch (RuntimeException e)
@@ -484,7 +484,7 @@ public class HttpCatalogTest
 
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
 
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:12345")),
+        TupleIterator it = function.execute(context, "http", List.of(ExpressionTestUtils.createStringExpression("http://localhost:12345")),
                 asList(new Option(HttpCatalog.FAIL_ON_NON_200, ExpressionTestUtils.createStringExpression("false"))));
         assertFalse(it.hasNext());
     }
@@ -503,7 +503,7 @@ public class HttpCatalogTest
 
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
 
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())),
+        TupleIterator it = function.execute(context, "http", List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort())),
                 asList(new Option(HttpCatalog.FAIL_ON_NON_200, ExpressionTestUtils.createStringExpression("false"))));
         assertFalse(it.hasNext());
         mockServer.verify(mocks[0].getId());
@@ -530,7 +530,7 @@ public class HttpCatalogTest
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
 
         //@formatter:off
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort() + "/api")), List.of(
+        TupleIterator it = function.execute(context, "http", List.of(ExpressionTestUtils.createStringExpression("http://localhost:" + mockServer.getPort() + "/api")), List.of(
                 new Option(HttpCatalog.METHOD, methodExpression),
                 new Option(QueryFunction.BODY, bodyExpression),
                 new Option(QualifiedName.of(HttpCatalog.HEADER, "x-header"), x_headerExpression))
@@ -577,7 +577,7 @@ public class HttpCatalogTest
 
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
         //@formatter:off
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/api")), List.of(
+        TupleIterator it = function.execute(context, "http", List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/api")), List.of(
                 new Option(HttpCatalog.METHOD, methodExpression),
                 new Option(QualifiedName.of("jsonpath"), jsonpathExpression),
                 new Option(QueryFunction.BODY, bodyExpression),
@@ -621,7 +621,7 @@ public class HttpCatalogTest
 
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
 
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/csv")), emptyList());
+        TupleIterator it = function.execute(context, "http", List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/csv")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -667,7 +667,7 @@ public class HttpCatalogTest
         IExpression xmlPathExpression = createStringExpression("/keys/key");
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
 
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/xml")),
+        TupleIterator it = function.execute(context, "http", List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/xml")),
                 List.of(new Option(QualifiedName.of("xmlpath"), xmlPathExpression)));
 
         int rowCount = 0;
@@ -708,7 +708,7 @@ public class HttpCatalogTest
 
         IExecutionContext context = TestUtils.mockExecutionContext("http", emptyMap(), 0, null);
 
-        TupleIterator it = function.execute(context, "http", Optional.empty(), List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/csv")),
+        TupleIterator it = function.execute(context, "http", List.of(createStringExpression("http://localhost:" + mockServer.getPort() + "/csv")),
                 List.of(new Option(QualifiedName.of("columnseparator"), columnSeparatorExpression)));
 
         int rowCount = 0;

--- a/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/jdbc/BaseJDBCTest.java
+++ b/payloadbuilder-catalog/src/test/java/se/kuseman/payloadbuilder/catalog/jdbc/BaseJDBCTest.java
@@ -192,7 +192,7 @@ abstract class BaseJDBCTest extends Assert
         IExecutionContext context = mockExecutionContext(writer);
         QueryFunction query = new QueryFunction(catalog);
 
-        TupleIterator it = query.execute(context, CATALOG_ALIAS, Optional.empty(), asList(ExpressionTestUtils.createStringExpression("""
+        TupleIterator it = query.execute(context, CATALOG_ALIAS, asList(ExpressionTestUtils.createStringExpression("""
                 raiserror('warn 0', 0, 2);       -- Warn level
                 create table vals
                 (

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenCsvFunction.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenCsvFunction.java
@@ -7,7 +7,6 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -74,7 +73,7 @@ class OpenCsvFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         ValueVector value = arguments.get(0)
                 .eval(context);

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenJsonFunction.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenJsonFunction.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -71,7 +70,7 @@ class OpenJsonFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         ValueVector value = arguments.get(0)
                 .eval(context);

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenTableFunction.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenTableFunction.java
@@ -1,7 +1,6 @@
 package se.kuseman.payloadbuilder.core.catalog.system;
 
 import java.util.List;
-import java.util.Optional;
 
 import se.kuseman.payloadbuilder.api.catalog.Column;
 import se.kuseman.payloadbuilder.api.catalog.Option;
@@ -56,7 +55,7 @@ class OpenTableFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         final ValueVector vector = arguments.get(0)
                 .eval(context);
@@ -72,7 +71,7 @@ class OpenTableFunction extends TableFunctionInfo
             @Override
             public Schema getSchema()
             {
-                return schema.orElse(table.getSchema());
+                return table.getSchema();
             }
 
             @Override

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenXmlFunction.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/OpenXmlFunction.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -88,7 +87,7 @@ class OpenXmlFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         ValueVector value = arguments.get(0)
                 .eval(context);

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/RangeFunction.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/RangeFunction.java
@@ -2,7 +2,6 @@ package se.kuseman.payloadbuilder.core.catalog.system;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import se.kuseman.payloadbuilder.api.catalog.Column;
 import se.kuseman.payloadbuilder.api.catalog.Column.Type;
@@ -39,7 +38,7 @@ class RangeFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         ValueVector vv;
 
@@ -82,7 +81,7 @@ class RangeFunction extends TableFunctionInfo
 
         if (rowCount <= batchSize)
         {
-            return TupleIterator.singleton(getVector(schema.get(), start, stop));
+            return TupleIterator.singleton(getVector(SCHEMA, start, stop));
         }
 
         final int batchCount = rowCount / batchSize;
@@ -132,7 +131,7 @@ class RangeFunction extends TableFunctionInfo
 
                     int batchStart = start + (batchSize * batchNumber);
                     int batchStop = Math.min(batchStart + batchSize, stop);
-                    next = getVector(schema.get(), batchStart, batchStop);
+                    next = getVector(SCHEMA, batchStart, batchStop);
                     batchNumber++;
                 }
                 return true;

--- a/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/StringSplitTableFunction.java
+++ b/payloadbuilder-core/src/main/java/se/kuseman/payloadbuilder/core/catalog/system/StringSplitTableFunction.java
@@ -3,7 +3,6 @@ package se.kuseman.payloadbuilder.core.catalog.system;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -44,7 +43,7 @@ class StringSplitTableFunction extends TableFunctionInfo
     }
 
     @Override
-    public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+    public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
     {
         final ValueVector value = arguments.get(0)
                 .eval(context);
@@ -77,6 +76,6 @@ class StringSplitTableFunction extends TableFunctionInfo
             resultVector.setString(i, UTF8String.from(parts[i]));
         }
 
-        return TupleIterator.singleton(TupleVector.of(schema.get(), List.of(resultVector, ValueVector.range(0, length))));
+        return TupleIterator.singleton(TupleVector.of(SCHEMA, List.of(resultVector, ValueVector.range(0, length))));
     }
 }

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/OpenCsvFunctionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/OpenCsvFunctionTest.java
@@ -9,7 +9,6 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Test;
@@ -37,14 +36,14 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
     public void test_empty_on_null()
     {
         assertEquals(Arity.ONE, f.arity());
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("null")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("null")), emptyList());
         assertFalse(it.hasNext());
     }
 
     @Test
     public void test_only_headers()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 'col1,col2,col3
                 '
                 """)), emptyList());
@@ -73,7 +72,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
     @Test
     public void test_batch_size()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 'key
                 123
                 456
@@ -117,7 +116,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
     @Test
     public void test_missing_column_value()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 'key,key2
                 123
                 1230,4560
@@ -149,7 +148,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
     @Test
     public void test()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 'key,key2
                 123,1230
                 1230,4560
@@ -181,7 +180,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
     @Test
     public void test_column_separator()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 'key;key2
                 123;1230
                 1230;4560
@@ -213,7 +212,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
     @Test
     public void test_column_separator_headers()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 '123;1230
                 1230;4560
                 '
@@ -263,7 +262,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
         Mockito.when(arg.eval(Mockito.any()))
                 .thenReturn(VectorTestUtils.vv(Column.Type.Any, reader));
 
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(arg), emptyList());
+        TupleIterator it = f.execute(context, "", asList(arg), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -311,7 +310,7 @@ public class OpenCsvFunctionTest extends APhysicalPlanTest
         Mockito.when(arg.eval(Mockito.any()))
                 .thenReturn(VectorTestUtils.vv(Column.Type.Any, baos));
 
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(arg), emptyList());
+        TupleIterator it = f.execute(context, "", asList(arg), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/OpenJsonFunctionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/OpenJsonFunctionTest.java
@@ -10,7 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Test;
@@ -38,14 +37,14 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     public void test_empty_on_null()
     {
         assertEquals(Arity.ONE, f.arity());
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("null")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("null")), emptyList());
         assertFalse(it.hasNext());
     }
 
     @Test
     public void test_empty_object()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'{}'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'{}'")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -74,7 +73,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_object()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'{ \"key\": 123 }'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'{ \"key\": 123 }'")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -92,7 +91,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_empty_array()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[]'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'[]'")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -111,7 +110,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_array_object()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[{ \"key\": 123 },{ \"key2\": 456}]'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'[{ \"key\": 123 },{ \"key2\": 456}]'")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -136,7 +135,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_array_object_batch_size()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[{ \"key\": 123 },{ \"key2\": 456}]'")), List.of(new Option(IExecutionContext.BATCH_SIZE, intLit(1))));
+        TupleIterator it = f.execute(context, "", asList(e("'[{ \"key\": 123 },{ \"key2\": 456}]'")), List.of(new Option(IExecutionContext.BATCH_SIZE, intLit(1))));
 
         int batchCount = 0;
         int rowCount = 0;
@@ -175,7 +174,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_array_object_empty_row()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}]'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}]'")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -200,7 +199,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_pointer_not_found()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}]'")), List.of(new Option(OpenJsonFunction.JSONPATH, e("'/none'"))));
+        TupleIterator it = f.execute(context, "", asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}]'")), List.of(new Option(OpenJsonFunction.JSONPATH, e("'/none'"))));
 
         assertFalse(it.hasNext());
         it.close();
@@ -209,7 +208,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_pointer_to_array()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'{\"rows\": [{ \"key\": 123 },{ \"key2\": 456},{}], \"otherData\": { \"key\":234 }}'")),
+        TupleIterator it = f.execute(context, "", asList(e("'{\"rows\": [{ \"key\": 123 },{ \"key2\": 456},{}], \"otherData\": { \"key\":234 }}'")),
                 List.of(new Option(OpenJsonFunction.JSONPATH, e("'/rows'"))));
 
         int rowCount = 0;
@@ -235,8 +234,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_pointer_to_object()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'{\"otherData\": { \"key\":234 }, \"row\": { \"key\": 123 }}'")),
-                List.of(new Option(OpenJsonFunction.JSONPATH, e("'/row'"))));
+        TupleIterator it = f.execute(context, "", asList(e("'{\"otherData\": { \"key\":234 }, \"row\": { \"key\": 123 }}'")), List.of(new Option(OpenJsonFunction.JSONPATH, e("'/row'"))));
 
         int rowCount = 0;
         while (it.hasNext())
@@ -260,7 +258,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_pointer_to_empty_object()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'{\"otherData\": { \"key\":234 }, \"row\": {}}'")), List.of(new Option(OpenJsonFunction.JSONPATH, e("'/row'"))));
+        TupleIterator it = f.execute(context, "", asList(e("'{\"otherData\": { \"key\":234 }, \"row\": {}}'")), List.of(new Option(OpenJsonFunction.JSONPATH, e("'/row'"))));
 
         int rowCount = 0;
         while (it.hasNext())
@@ -277,8 +275,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_pointer_to_empty_array()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'{\"otherData\": { \"key\":234 }, \"rows\": []}'")),
-                List.of(new Option(OpenJsonFunction.JSONPATH, e("'/rows'"))));
+        TupleIterator it = f.execute(context, "", asList(e("'{\"otherData\": { \"key\":234 }, \"rows\": []}'")), List.of(new Option(OpenJsonFunction.JSONPATH, e("'/rows'"))));
 
         assertFalse(it.hasNext());
         assertFalse(it.hasNext());
@@ -288,7 +285,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_array_mixed_values()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}, true]'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}, true]'")), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -312,7 +309,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
     @Test
     public void test_array_broken_json_last()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}, true'")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("'[{ \"key\": 123 },{ \"key2\": 456},{}, true'")), emptyList());
 
         try
         {
@@ -344,7 +341,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
         Mockito.when(arg.eval(Mockito.any()))
                 .thenReturn(VectorTestUtils.vv(Column.Type.Any, reader));
 
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(arg), emptyList());
+        TupleIterator it = f.execute(context, "", asList(arg), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())
@@ -389,7 +386,7 @@ public class OpenJsonFunctionTest extends APhysicalPlanTest
         Mockito.when(arg.eval(Mockito.any()))
                 .thenReturn(VectorTestUtils.vv(Column.Type.Any, baos));
 
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(arg), emptyList());
+        TupleIterator it = f.execute(context, "", asList(arg), emptyList());
 
         int rowCount = 0;
         while (it.hasNext())

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/OpenXmlFunctionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/OpenXmlFunctionTest.java
@@ -10,7 +10,6 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Test;
@@ -40,14 +39,14 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     public void test_empty_on_null()
     {
         assertEquals(Arity.ONE, f.arity());
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("null")), emptyList());
+        TupleIterator it = f.execute(context, "", asList(e("null")), emptyList());
         assertFalse(it.hasNext());
     }
 
     @Test
     public void test_empty_xml()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 '<xml />'
                 """)), List.of(new Option(OpenXmlFunction.XMLPATH, e("'/'"))));
 
@@ -66,7 +65,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_empty_xml_node_but_with_attributes()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 '<xml attr1="1234" />'
                 """)), List.of(new Option(OpenXmlFunction.XMLPATH, e("'/'"))));
 
@@ -94,7 +93,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_batch_size()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -148,7 +147,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_batch_size_with_only_new_columns()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -202,7 +201,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_complex_xml_cdata()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                                 `<records>
                                   <record>
                                       <value attr1="666">123</value>
@@ -268,7 +267,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -309,7 +308,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_columns_option()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -351,7 +350,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     public void test_columns_option_2()
     {
         // Columns should come in the order specified in options and not in the order present in XML
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -393,7 +392,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_columns_option_with_null_values()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -432,7 +431,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_pointer_to_a_deep_nested_element()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                       <record>
@@ -476,7 +475,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_no_path()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -517,7 +516,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_root_path()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -558,7 +557,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_totally_different_columns_on_rows()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -604,7 +603,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_not_found_path()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -627,7 +626,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     {
         // Here we will get an array of values since <record> exists multiple times
         // under the xmlpath
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -668,7 +667,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_arrays()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <campaigns>
                       <value>camp1</value>
@@ -703,7 +702,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_arrays_from_attributes()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <campaigns>
                       <value attr="camp1" />
@@ -738,7 +737,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_single_scalar_value_pointer()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <campaigns>
                       <value>camp1</value>
@@ -773,7 +772,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_single_scalar_value_pointer_2()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <campaign>
                       <name>camp1</name>
@@ -807,7 +806,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_single_scalar_value_pointer_3()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <campaign>
                       <name>camp1</name>
@@ -847,7 +846,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_new_columns_second_row()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(e("""
+        TupleIterator it = f.execute(context, "", asList(e("""
                 `<?xml version="1.0" encoding="UTF-8"?>
                   <records>
                   <record>
@@ -894,7 +893,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
     @Test
     public void test_product()
     {
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null),
+        TupleIterator it = f.execute(context, "",
                 asList(e(
                         """
                                 `<?xml version="1.0" encoding="UTF-8"?>
@@ -1087,7 +1086,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
         Mockito.when(arg.eval(Mockito.any()))
                 .thenReturn(VectorTestUtils.vv(Column.Type.Any, reader));
 
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(arg), List.of(new Option(OpenXmlFunction.XMLPATH, e("'/records/record'"))));
+        TupleIterator it = f.execute(context, "", asList(arg), List.of(new Option(OpenXmlFunction.XMLPATH, e("'/records/record'"))));
 
         int rowCount = 0;
         while (it.hasNext())
@@ -1143,7 +1142,7 @@ public class OpenXmlFunctionTest extends APhysicalPlanTest
         Mockito.when(arg.eval(Mockito.any()))
                 .thenReturn(VectorTestUtils.vv(Column.Type.Any, baos));
 
-        TupleIterator it = f.execute(context, "", Optional.ofNullable(null), asList(arg), List.of(new Option(OpenXmlFunction.XMLPATH, e("'/records/record'"))));
+        TupleIterator it = f.execute(context, "", asList(arg), List.of(new Option(OpenXmlFunction.XMLPATH, e("'/records/record'"))));
 
         int rowCount = 0;
         while (it.hasNext())

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/RangeFunctionTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/catalog/system/RangeFunctionTest.java
@@ -5,8 +5,6 @@ import static java.util.Collections.emptyList;
 import static se.kuseman.payloadbuilder.test.VectorTestUtils.assertVectorsEquals;
 import static se.kuseman.payloadbuilder.test.VectorTestUtils.vv;
 
-import java.util.Optional;
-
 import org.junit.Test;
 
 import se.kuseman.payloadbuilder.api.QualifiedName;
@@ -32,7 +30,7 @@ public class RangeFunctionTest extends APhysicalPlanTest
     public void test()
     {
         Schema schema = Schema.of(Column.of("Value", ResolvedType.of(Type.Int)));
-        TupleIterator it = f.execute(context, "", Optional.of(schema), asList(intLit(1), intLit(10)), emptyList());
+        TupleIterator it = f.execute(context, "", asList(intLit(1), intLit(10)), emptyList());
 
         int count = 0;
         while (it.hasNext())
@@ -52,7 +50,7 @@ public class RangeFunctionTest extends APhysicalPlanTest
     {
         Schema schema = Schema.of(Column.of("Value", ResolvedType.of(Type.Int)));
         context.setVariable("batch", ValueVector.literalInt(3, 1));
-        TupleIterator it = f.execute(context, "", Optional.of(schema), asList(intLit(1), intLit(11)), asList(new Option(QualifiedName.of("batch_size"), new VariableExpression("batch"))));
+        TupleIterator it = f.execute(context, "", asList(intLit(1), intLit(11)), asList(new Option(QualifiedName.of("batch_size"), new VariableExpression("batch"))));
 
         int count = 0;
         while (it.hasNext())

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/TableFunctionScanTest.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/physicalplan/TableFunctionScanTest.java
@@ -3,12 +3,22 @@ package se.kuseman.payloadbuilder.core.physicalplan;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
+import java.util.List;
+
 import org.junit.Test;
 
+import se.kuseman.payloadbuilder.api.catalog.Column;
 import se.kuseman.payloadbuilder.api.catalog.Column.Type;
+import se.kuseman.payloadbuilder.api.catalog.Option;
 import se.kuseman.payloadbuilder.api.catalog.ResolvedType;
 import se.kuseman.payloadbuilder.api.catalog.Schema;
+import se.kuseman.payloadbuilder.api.catalog.TableFunctionInfo;
+import se.kuseman.payloadbuilder.api.execution.IExecutionContext;
+import se.kuseman.payloadbuilder.api.execution.TupleIterator;
 import se.kuseman.payloadbuilder.api.execution.TupleVector;
+import se.kuseman.payloadbuilder.api.execution.ValueVector;
+import se.kuseman.payloadbuilder.api.expression.IExpression;
+import se.kuseman.payloadbuilder.core.QueryException;
 import se.kuseman.payloadbuilder.core.catalog.system.SystemCatalog;
 
 /** Test {@link TableFunctionScan} */
@@ -24,5 +34,108 @@ public class TableFunctionScanTest extends APhysicalPlanTest
         TupleVector vector = PlanUtils.concat(context, plan.execute(context));
 
         assertEquals(schema, vector.getSchema());
+    }
+
+    @Test
+    public void test_validation_asterisk_with_empty_runtime_schema()
+    {
+        Schema schema = Schema.of(ast("col", table));
+        IPhysicalPlan plan = new TableFunctionScan(0, schema, table, "", "System", new TableFunctionInfo("dummy")
+        {
+
+            @Override
+            public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
+            {
+                return TupleIterator.singleton(TupleVector.CONSTANT);
+            }
+        }, emptyList(), emptyList());
+        try
+        {
+            plan.execute(context)
+                    .next();
+            fail("Should fail");
+        }
+        catch (QueryException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("returned an empty schema"));
+        }
+    }
+
+    @Test
+    public void test_validation_not_matching_runtime_schema_by_size()
+    {
+        Schema schema = Schema.of(col("Value", ResolvedType.of(Type.Int), table), col("Value2", ResolvedType.of(Type.Int), table));
+        IPhysicalPlan plan = new TableFunctionScan(0, schema, table, "", "System", new TableFunctionInfo("dummy")
+        {
+
+            @Override
+            public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
+            {
+                return TupleIterator.singleton(TupleVector.of(Schema.of(Column.of("Value1", ResolvedType.INT)), ValueVector.literalInt(1, 1)));
+            }
+        }, emptyList(), emptyList());
+        try
+        {
+            plan.execute(context)
+                    .next();
+            fail("Should fail");
+        }
+        catch (QueryException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("doesn't match the planned schema"));
+        }
+    }
+
+    @Test
+    public void test_validation_not_matching_runtime_schema_by_column()
+    {
+        Schema schema = Schema.of(col("Value", ResolvedType.of(Type.Int), table));
+        IPhysicalPlan plan = new TableFunctionScan(0, schema, table, "", "System", new TableFunctionInfo("dummy")
+        {
+
+            @Override
+            public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
+            {
+                return TupleIterator.singleton(TupleVector.of(Schema.of(Column.of("Value1", ResolvedType.INT)), ValueVector.literalInt(1, 1)));
+            }
+        }, emptyList(), emptyList());
+        try
+        {
+            plan.execute(context)
+                    .next();
+            fail("Should fail");
+        }
+        catch (QueryException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("doesn't match the planned schema"));
+        }
+    }
+
+    @Test
+    public void test_validation_not_matching_runtime_schema_by_type()
+    {
+        Schema schema = Schema.of(col("Value", ResolvedType.of(Type.Int), table));
+        IPhysicalPlan plan = new TableFunctionScan(0, schema, table, "", "System", new TableFunctionInfo("dummy")
+        {
+            @Override
+            public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
+            {
+                return TupleIterator.singleton(TupleVector.of(Schema.of(Column.of("Value", ResolvedType.FLOAT)), ValueVector.literalFloat(1, 1)));
+            }
+        }, emptyList(), emptyList());
+        try
+        {
+            plan.execute(context)
+                    .next();
+            fail("Should fail");
+        }
+        catch (QueryException e)
+        {
+            assertTrue(e.getMessage(), e.getMessage()
+                    .contains("doesn't match the planned schema"));
+        }
     }
 }

--- a/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/test/TestHarnessRunner.java
+++ b/payloadbuilder-core/src/test/java/se/kuseman/payloadbuilder/core/test/TestHarnessRunner.java
@@ -15,7 +15,6 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -369,7 +368,7 @@ public class TestHarnessRunner
                 }
 
                 @Override
-                public TupleIterator execute(IExecutionContext context, String catalogAlias, Optional<Schema> schema, List<IExpression> arguments, List<Option> options)
+                public TupleIterator execute(IExecutionContext context, String catalogAlias, List<IExpression> arguments, List<Option> options)
                 {
                     // Returns a tuple vector with all options evaluated
                     List<Column> columns = new ArrayList<>();


### PR DESCRIPTION
…d. It was only confusing and made no sense,

now instead the returned vectors are adjusted/validated in TableFunctionScan instead to ease the burden of catalog implementations